### PR TITLE
22a Scoping: Recursion

### DIFF
--- a/pseudocode/lang.py
+++ b/pseudocode/lang.py
@@ -126,7 +126,8 @@ class Frame:
     delete(name)
         deletes the slot associated with the name
     """
-    def __init__(self):
+    def __init__(self, outer=None):
+        self.outer = outer
         self.data = {}
 
     def __repr__(self):

--- a/pseudocode/lang.py
+++ b/pseudocode/lang.py
@@ -61,6 +61,30 @@ class Procedure(Callable):
 
 
 
+class Builtin(Value):
+    """
+    Represents a system function in pseudo.
+
+    Attributes
+    ----------
+    - params
+        A list of parameters used by the callable
+    - func
+        the Python function to call when invoked
+    """
+    __slots__ = ('params', 'func')
+    def __init__(self, params, func):
+        self.params = params
+        self.func = func
+
+    def __repr__(self):
+        attrstr = ", ".join([
+            repr(getattr(self, attr)) for attr in self.__slots__
+        ])
+        return f'{type(self).__name__}({attrstr})'
+
+
+
 class File(Value):
     """
     Represents a file object in a frame.
@@ -312,15 +336,6 @@ class Input(Stmt):
     def __init__(self, rule, name):
         self.rule = rule
         self.name = name
-
-
-
-# class Assign(Stmt):
-#     __slots__ = ('rule', 'name', 'expr')
-#     def __init__(self, rule, name, expr):
-#         self.rule = rule
-#         self.name = name
-#         self.expr = expr
 
 
 

--- a/pseudocode/lang.py
+++ b/pseudocode/lang.py
@@ -125,6 +125,8 @@ class Frame:
         updates the value associated with the name
     delete(name)
         deletes the slot associated with the name
+    lookup(name)
+        returns the first frame containing the name
     """
     def __init__(self, outer=None):
         self.outer = outer
@@ -157,6 +159,12 @@ class Frame:
 
     def delete(self, name):
         del self.data[name]
+
+    def lookup(self, name):
+        if self.has(name):
+            return self
+        if self.outer:
+            return self.outer.lookup(name)
 
 
 

--- a/pseudocode/resolver.py
+++ b/pseudocode/resolver.py
@@ -111,6 +111,10 @@ def resolveAssign(frame, expr):
 def resolveGet(frame, expr):
     """Insert frame into Get expr"""
     assert isinstance(expr, Get), "Not a Get Expr"
+    if not frame.has(expr.name):
+        frame = frame.lookup(expr.name)
+    if not frame:
+        raise LogicError("Undeclared", expr.name.token())
     expr.frame = frame
     return frame.getType(expr.name)
 

--- a/pseudocode/resolver.py
+++ b/pseudocode/resolver.py
@@ -142,7 +142,7 @@ def resolveCall(frame, expr):
     type-checking. These should be carried out first (e.g. in a wrapper
     function) before resolveCall() is invoked.
     """
-    callable = frame.getValue(expr.callable.name)
+    callable = expr.callable.frame.getValue(expr.callable.name)
     numArgs, numParams = len(expr.args), len(callable.params)
     if numArgs != numParams:
         raise LogicError(

--- a/tests/test_recursion.py
+++ b/tests/test_recursion.py
@@ -1,0 +1,38 @@
+import unittest
+
+import pseudocode
+from tests import capture
+
+TESTCODE = """
+PROCEDURE CountDownThenUp(Num : INTEGER)
+    OUTPUT Num
+    IF Num > 0
+      THEN
+        OUTPUT CountDown(Num - 1)
+    ENDIF
+ENDPROCEDURE
+
+CALL CountDownThenUp(10)
+"""
+
+class RecursionTestCase(unittest.TestCase):
+    def setUp(self):
+        pseudo = pseudocode.Pseudo()
+        captureOutput, returnOutput = capture('output')
+        pseudo.registerHandlers(
+            output=captureOutput,
+        )
+        self.result = pseudo.run(TESTCODE)
+        self.result['output'] = returnOutput()
+        
+    def test_recursion(self):
+        # Procedure should complete successfully
+        self.assertIsNone(self.result['error'])        
+
+    def test_output(self):
+        # Check output
+        output = self.result['output']
+        self.assertEqual(
+            output,
+            "10\n9\n8\n7\n6\n5\n4\n3\n2\n1\n0",
+        )

--- a/tests/test_recursion.py
+++ b/tests/test_recursion.py
@@ -8,7 +8,7 @@ PROCEDURE CountDown(Num : INTEGER)
     OUTPUT Num
     IF Num > 0
       THEN
-        OUTPUT CountDown(Num - 1)
+        CALL CountDown(Num - 1)
     ENDIF
 ENDPROCEDURE
 
@@ -33,6 +33,6 @@ class RecursionTestCase(unittest.TestCase):
         # Check output
         output = self.result['output']
         self.assertEqual(
-            output,
+            output.strip(),
             "10\n9\n8\n7\n6\n5\n4\n3\n2\n1\n0",
         )

--- a/tests/test_recursion.py
+++ b/tests/test_recursion.py
@@ -4,7 +4,7 @@ import pseudocode
 from tests import capture
 
 TESTCODE = """
-PROCEDURE CountDownThenUp(Num : INTEGER)
+PROCEDURE CountDown(Num : INTEGER)
     OUTPUT Num
     IF Num > 0
       THEN
@@ -12,7 +12,7 @@ PROCEDURE CountDownThenUp(Num : INTEGER)
     ENDIF
 ENDPROCEDURE
 
-CALL CountDownThenUp(10)
+CALL CountDown(10)
 """
 
 class RecursionTestCase(unittest.TestCase):


### PR DESCRIPTION
The next thing I want to do actually is to implement some built-in functions, like `RND()` and `RANDOMBETWEEN()`. But something more pressing awaits: while pseudo alloss us to declare FUNCTIONs and PROCEDUREs in global space, we can't actually call them from within a PROCEDURE or FUNCTION yet.

And that is because so far, the local scopes only declare whatever parameters they are defined with. We have yet to introduce the wider notion of global scope, where any names declared are available to all function/procedure calls. And we'll need this because ... where else are we going to put built-in functions?

And, in an oblique roundabout way, we are going to approach this by tackling recursion first. After all, recursion involves a procedure/function calling itself, which has to first be declared in the global scope right? Solve that and almost everything else will work.