### PR TITLE
24a Improvements: type annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,24 @@ pip install pseudo-9608
 
 ## Usage
 
+### Running psuedocode on a file
+
 ```
 import pseudocode
 
-pseudocode.run('myfile.pseudo')
+pseudocode.runFile('myfile.pseudo')
+```
+
+### Running psuedocode on a string
+
+```
+import pseudocode
+
+code = """
+OUTPUT "Hello World!"
+"""
+
+pseudocode.run(code)
 ```
 
 # Chapters

--- a/pseudocode/__init__.py
+++ b/pseudocode/__init__.py
@@ -1,6 +1,6 @@
 from typing import Iterable, Mapping, Callable as function
 
-import builtin
+from . import builtin
 from .lang import Frame
 from .system import system
 

--- a/pseudocode/__init__.py
+++ b/pseudocode/__init__.py
@@ -1,4 +1,6 @@
 from typing import Iterable, Mapping, Callable as function
+from sys import exc_info
+from traceback import format_exception
 
 from . import builtin
 from .lang import Frame
@@ -13,6 +15,12 @@ from .interpreter import Interpreter
 __version__ = '0.2.1'
 
 
+
+# https://stackoverflow.com/a/66416364/318186
+def printException():
+    etype, value, tb = exc_info()
+    info, error = format_exception(etype, value, tb)[-2:]
+    print(f'Exception in:\n{info}\n{error}')
 
 def error(lines: Iterable, err: builtin.PseudoError) -> None:
     errType = type(err).__name__ + ':'
@@ -61,8 +69,9 @@ class Pseudo:
         except builtin.ParseError as err:
             result['error'] = err
             return result
-        except Exception as err:
-            breakpoint()
+        except Exception:
+            printException()
+            return result
 
         # Resolving
         resolver = Resolver(globalFrame, statements)
@@ -71,8 +80,9 @@ class Pseudo:
         except builtin.LogicError as err:
             result['error'] = err
             return result
-        except Exception as err:
-            breakpoint()
+        except Exception:
+            printException()
+            return result
 
         # Interpreting
         interpreter = Interpreter(globalFrame, statements)
@@ -81,7 +91,7 @@ class Pseudo:
             interpreter.interpret()
         except builtin.RuntimeError as err:
             result['error'] = err
-        except Exception as err:
-            breakpoint()
+        except Exception:
+            printException()
         finally:
             return result

--- a/pseudocode/__init__.py
+++ b/pseudocode/__init__.py
@@ -1,4 +1,6 @@
-from .builtin import ParseError, RuntimeError, LogicError
+from typing import Iterable, Mapping, Callable as function
+
+import builtin
 from .lang import Frame
 from .system import system
 
@@ -12,7 +14,7 @@ __version__ = '0.2.1'
 
 
 
-def error(lines, err):
+def error(lines: Iterable, err: builtin.PseudoError) -> None:
     errType = type(err).__name__ + ':'
     if err.line:
         lineinfo = f"[Line {err.line}]"
@@ -26,24 +28,24 @@ def error(lines, err):
 
 class Pseudo:
     """A 9608 pseudocode interpreter"""
-    def __init__(self):
+    def __init__(self) -> None:
         self.handlers = {
             'output': print,
             'input': input,
         }
 
-    def registerHandlers(self, **kwargs):
+    def registerHandlers(self, **kwargs: Mapping[str, function]) -> None:
         for key, handler in kwargs.items():
             if key not in self.handlers:
                 raise KeyError(f"Invalid handler key {repr(key)}")
             self.handlers[key] = handler
 
-    def runFile(self, srcfile):
+    def runFile(self, srcfile: str) -> "Frame":
         with open(srcfile, 'r') as f:
             src = f.read()
         return self.run(src)
     
-    def run(self, src):
+    def run(self, src: str) -> "Frame":
         globalFrame = Frame(typesys=system.types, outer=system)
         result = {
             'lines': None,
@@ -56,7 +58,7 @@ class Pseudo:
             tokens, lines = scanner.scan(src)
             result['lines'] = lines
             statements = parser.parse(tokens)
-        except ParseError as err:
+        except builtin.ParseError as err:
             result['error'] = err
             return result
         except Exception as err:
@@ -66,7 +68,7 @@ class Pseudo:
         resolver = Resolver(globalFrame, statements)
         try:
             resolver.inspect()
-        except LogicError as err:
+        except builtin.LogicError as err:
             result['error'] = err
             return result
         except Exception as err:
@@ -77,7 +79,7 @@ class Pseudo:
         interpreter.registerOutputHandler(self.handlers['output'])
         try:
             interpreter.interpret()
-        except RuntimeError as err:
+        except builtin.RuntimeError as err:
             result['error'] = err
         except Exception as err:
             breakpoint()

--- a/pseudocode/__init__.py
+++ b/pseudocode/__init__.py
@@ -1,6 +1,5 @@
 from .builtin import ParseError, RuntimeError, LogicError
-from .builtin import TYPES
-from .lang import Frame, TypeSystem
+from .lang import Frame
 from .system import system
 
 from . import scanner, parser

--- a/pseudocode/builtin.py
+++ b/pseudocode/builtin.py
@@ -5,11 +5,9 @@ class PseudoError(Exception):
     def __init__(self, msg, token, line=None):
         super().__init__(msg)
         self.token = token
-        self.line = None
+        self.line = line
         self.col = None
-        if line is not None:
-            self.line = line
-        elif type(token) is dict:
+        if token:
             self.line = token.line
             self.col = token.col
         else:

--- a/pseudocode/interpreter.py
+++ b/pseudocode/interpreter.py
@@ -1,4 +1,4 @@
-from typing import Optional, Iterable, Callable as function
+from typing import Optional, Iterable, Tuple, Callable as function
 
 from . import builtin, lang, system
 

--- a/pseudocode/interpreter.py
+++ b/pseudocode/interpreter.py
@@ -20,7 +20,7 @@ def expectTypeElseError(
 
 def declaredElseError(
     frame: lang.Frame,
-    name: lang.Name,
+    name: lang.Varname,
     errmsg: str="Undeclared",
     token: lang.Token=None,
 ) -> None:
@@ -29,7 +29,7 @@ def declaredElseError(
 
 def undeclaredElseError(
     frame: lang.Frame,
-    name: lang.Name,
+    name: lang.Varname,
     errmsg="Already declared",
     token: lang.Token=None,
 ) -> None:

--- a/pseudocode/interpreter.py
+++ b/pseudocode/interpreter.py
@@ -242,9 +242,7 @@ def execute(frame, stmt, *args, **kwargs):
     if stmt.rule == 'output':
         execOutput(frame, stmt, **kwargs)
     if stmt.rule == 'input':
-        stmt.accept(frame, execInput(frame, stmt, **kwargs)
-    if stmt.rule == 'assign':
-        evaluate(frame, stmt.expr, **kwargs)
+        execInput(frame, stmt, **kwargs)
     if stmt.rule == 'case':
         execCase(frame, stmt, **kwargs)
     if stmt.rule == 'if':
@@ -255,6 +253,8 @@ def execute(frame, stmt, *args, **kwargs):
         execRepeat(frame, stmt, **kwargs)
     if stmt.rule == 'call':
         evalCall(frame, stmt.expr, **kwargs)
+    if stmt.rule == 'assign':
+        evaluate(frame, stmt.expr, **kwargs)
     if stmt.rule == 'return':
         return evaluate(frame, stmt.expr, **kwargs)
     if stmt.rule == 'file':

--- a/pseudocode/interpreter.py
+++ b/pseudocode/interpreter.py
@@ -64,8 +64,8 @@ class Interpreter:
 
 def evalIndex(frame, indexes):
     return tuple((
-        evaluate(frame, indexExpr)
-        for indexExpr in indexes
+        evaluate(frame, expr)
+        for expr in indexes
     ))
 
 def evalLiteral(frame, literal):

--- a/pseudocode/lang.py
+++ b/pseudocode/lang.py
@@ -396,7 +396,7 @@ class Name(Expr):
     __slots__ = ('name',)
     def __init__(
         self,
-        name: Name,
+        name: Varname,
         token: "Token"=None,
     ) -> None:
         super().__init__(token=token)
@@ -408,7 +408,7 @@ class Declare(Expr):
     __slots__ = ('name', 'type', 'metadata')
     def __init__(
         self,
-        name: Name,
+        name: Varname,
         type: Type,
         metadata: Mapping=None,
         token: "Token"=None,
@@ -424,7 +424,7 @@ class Assign(Expr):
     __slots__ = ('name', 'assignee', 'expr')
     def __init__(
         self,
-        name: Name,
+        name: Varname,
         assignee: "Get",
         expr: "Expr",
         token: "Token"=None) -> None:
@@ -470,7 +470,7 @@ class Get(Expr):
     def __init__(
         self,
         frame: "Frame",
-        name: Name,
+        name: Varname,
         token: "Token"=None,
     ) -> None:
         super().__init__(token=token)
@@ -531,7 +531,7 @@ class Input(Stmt):
     def __init__(
         self,
         rule: Rule,
-        name: Name,
+        name: Varname,
     ) -> None:
         self.rule = rule
         self.name = name
@@ -575,7 +575,7 @@ class ProcFunc(Stmt):
     def __init__(
         self,
         rule: Rule,
-        name: Name,
+        name: Varname,
         passby: str,
         params: Iterable[Param],
         stmts: Iterable["Stmt"],
@@ -595,7 +595,7 @@ class TypeStmt(Stmt):
     def __init__(
         self,
         rule: Rule,
-        name: Name,
+        name: Varname,
         exprs: Iterable["Expr"],
     ) -> None:
         self.rule = rule
@@ -610,7 +610,7 @@ class FileAction(Stmt):
         self,
         rule: Rule,
         action: str,
-        name: Name,
+        name: Varname,
         mode: str,
         data: "Expr",
     ) -> None:

--- a/pseudocode/lang.py
+++ b/pseudocode/lang.py
@@ -171,7 +171,7 @@ class Object(Value):
     def getType(self, name: Key) -> Type:
         return self.data[name].type
 
-    def getValue(self, name: Key) -> Val:
+    def getValue(self, name: Key) -> Optional[Val]:
         return self.data[name].value
 
     def get(self, name: Key) -> "TypedValue":
@@ -357,9 +357,10 @@ class Expr:
         Returns the token asociated with the expr, for error
         reporting purposes.
     """
+    __slots__ = NotImplemented
     def __init__(
         self,
-        token: "Token"=None,
+        token: "Token",
     ) -> None:
         self._token = token
 

--- a/pseudocode/lang.py
+++ b/pseudocode/lang.py
@@ -4,7 +4,7 @@ from typing import Callable as function, TextIO
 
 # Pseudocode types
 Type = str  # Built-in and declared types
-Name = str  # Variable names
+Varname = str  # Variable names
 Index = tuple  # Array indexes
 Key = Union[Name, Index]  # in TypedValue
 Lit = Union[bool, int, float, str]  # Simple data types

--- a/pseudocode/lang.py
+++ b/pseudocode/lang.py
@@ -1,4 +1,5 @@
-from typing import Any, Union, Iterable, Mapping
+from typing import Any, Optional, Union, Iterable, Mapping
+from typing import Dict
 from typing import Callable as function, TextIO
 
 # Pseudocode types
@@ -7,7 +8,7 @@ Name = str  # Variable names
 Index = tuple  # Array indexes
 Key = Union[Name, Index]  # in TypedValue
 Lit = Union[bool, int, float, str]  # Simple data types
-Val = Union[Lit, "Value"]  # in TypedValue
+Val = Union[Lit, "Value", "Object"]  # in TypedValue
 Param = Union["Get", "TypedValue"]  # Callable params
 Arg = "Expr"  # Call args
 Rule = str  # Stmt rules
@@ -59,7 +60,7 @@ class TypeSystem:
         self,
         *types: Type,
     ) -> None:
-        self.data = {}
+        self.data: Dict[Type, "TypedValue"] = {}
         for typeName in types:
             self.declare(typeName)
             self.setTemplate(typeName, None)
@@ -75,13 +76,13 @@ class TypeSystem:
         return name in self.data
 
     def declare(self, name: str) -> None:
-        self.data[name] = None
+        self.data[name] = TypedValue(name, None)
 
-    def setTemplate(self, name: str, template: "Object") -> None:
-        self.data[name] = TypedValue(name, template)
+    def setTemplate(self, name: str, template: Optional["Object"]) -> None:
+        self.data[name].value = template
 
-    def getTemplate(self, name) -> "Object":
-        return self.data[name]
+    def getTemplate(self, name) -> Optional[Val]:
+        return self.data[name].value
 
 
 
@@ -94,7 +95,7 @@ class TypedValue:
     def __init__(
         self,
         type: Type,
-        value: Val,
+        value: Optional[Val],
         *args: Any,
         **kwargs: Any,
     ) -> None:
@@ -150,7 +151,7 @@ class Object(Value):
         self,
         typesys: "TypeSystem",
     ) -> None:
-        self.data = {}
+        self.data: Dict[Key, "TypedValue"] = {}
         self.types = typesys
 
     def __repr__(self) -> str:

--- a/pseudocode/lang.py
+++ b/pseudocode/lang.py
@@ -1,111 +1,39 @@
+from typing import Any, Union, Iterable, Mapping
+from typing import Callable as function, TextIO
+
+# Pseudocode types
+Type = str  # Built-in and declared types
+Name = str  # Variable names
+Index = tuple  # Array indexes
+Key = Union[Name, Index]  # in TypedValue
+Lit = Union[bool, int, float, str]  # Simple data types
+Val = Union[Lit, "Value"]  # in TypedValue
+Param = Union["Get", "TypedValue"]  # Callable params
+Arg = "Expr"  # Call args
+Rule = str  # Stmt rules
+
+# ----------------------------------------------------------------------
 class Token:
     """
     Encapsulates data for a token.
     """
-    def __init__(self, line, column, type, word, value):
+    def __init__(
+        self,
+        line: int,
+        column: int,
+        type: Type,
+        word: str,
+        value: Any,
+    ) -> None:
         self.line = line
         self.col = column
         self.type = type
         self.word = word
         self.value = value
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         lineinfo = f"[Line {self.line} column {self.col}]"
         return f"{lineinfo} <{self.value}> {repr(self.word)}"
-
-
-
-class Value:
-    """
-    Base class for pseudo values.
-    Represents a value stored in the frame.
-    """
-
-
-
-class Callable(Value):
-    """
-    Base class for Function and Procedure.
-    Represents a Callable in pseudo.
-
-    Attributes
-    ----------
-    - frame
-        The frame used by the callable
-    - params
-        A list of parameters used by the callable
-    - stmts
-        A list of statements the callable executes when called
-    """
-    __slots__ = ('frame', 'params', 'stmts')
-    def __init__(self, frame, params, stmts):
-        self.frame = frame
-        self.params = params
-        self.stmts = stmts
-
-    def __repr__(self):
-        attrstr = ", ".join([
-            repr(getattr(self, attr)) for attr in self.__slots__
-        ])
-        return f'{type(self).__name__}({attrstr})'
-
-
-
-class Function(Callable):
-    """Functions are evaluated to return a value."""
-
-
-
-class Procedure(Callable):
-    """Procedures are called to execute its statements."""
-
-
-
-class Builtin(Value):
-    """
-    Represents a system function in pseudo.
-
-    Attributes
-    ----------
-    - params
-        A list of parameters used by the callable
-    - func
-        the Python function to call when invoked
-    """
-    __slots__ = ('params', 'func')
-    def __init__(self, params, func):
-        self.params = params
-        self.func = func
-
-    def __repr__(self):
-        attrstr = ", ".join([
-            repr(getattr(self, attr)) for attr in self.__slots__
-        ])
-        return f'{type(self).__name__}({attrstr})'
-
-
-
-class File(Value):
-    """
-    Represents a file object in a frame.
-
-    Attributes
-    ----------
-    - name
-        Name of the file that is open
-    - mode
-        The mode that the file was opened in
-    - iohandler
-        An object for accessing the file
-    """
-    __slots__ = ('name', 'mode', 'iohandler')
-    def __init__(self, name, mode, iohandler):
-        self.name = name
-        self.mode = mode
-        self.iohandler = iohandler
-
-    def __repr__(self):
-        return f"<{self.mode}: {self.name}>"
 
 
 
@@ -127,29 +55,32 @@ class TypeSystem:
     getTemplate(name)
         return the template of the type
     """
-    def __init__(self, *types):
+    def __init__(
+        self,
+        *types: Type,
+    ) -> None:
         self.data = {}
         for typeName in types:
             self.declare(typeName)
             self.setTemplate(typeName, None)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         nameTypePairs = [
             f"{name}: {self.getTemplate(name)}"
             for name in self.data
         ]
         return f"{{{', '.join(nameTypePairs)}}}"
 
-    def has(self, name):
+    def has(self, name: str) -> bool:
         return name in self.data
 
-    def declare(self, name):
+    def declare(self, name: str) -> None:
         self.data[name] = None
 
-    def setTemplate(self, name, template):
+    def setTemplate(self, name: str, template: "Object") -> None:
         self.data[name] = TypedValue(name, template)
 
-    def getTemplate(self, name):
+    def getTemplate(self, name) -> "Object":
         return self.data[name]
 
 
@@ -160,15 +91,21 @@ class TypedValue:
     Each TypedValue has a type and a value.
     """
     __slots__ = ('type', 'value')
-    def __init__(self, type, value, *args, **kwargs):
+    def __init__(
+        self,
+        type: Type,
+        value: Val,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
         super().__init__(*args, **kwargs)
         self.type = type
         self.value = value
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<{self.type}: {repr(self.value)}>"
 
-    def copy(self):
+    def copy(self) -> "TypedValue":
         """This returns an empty copy of the typedvalue"""
         Class = type(self)
         if isinstance(self.value, Object):
@@ -177,7 +114,15 @@ class TypedValue:
 
 
 
-class Object:
+class Value:
+    """
+    Base class for pseudo values.
+    Represents a value stored in the frame.
+    """
+
+
+
+class Object(Value):
     """
     Represents a space for storing of TypedValues in 9608 pseudocode.
     Provides methods for managing TypedValues.
@@ -201,37 +146,40 @@ class Object:
     copy()
         return a copy of the object
     """
-    def __init__(self, typesys):
+    def __init__(
+        self,
+        typesys: "TypeSystem",
+    ) -> None:
         self.data = {}
         self.types = typesys
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         nameTypePairs = [
             f"{name}: {self.getType(name)}"
             for name in self.data
         ]
         return f"{{{', '.join(nameTypePairs)}}}"
 
-    def has(self, name):
+    def has(self, name: Key) -> bool:
         return name in self.data
 
-    def declare(self, name, type):
+    def declare(self, name: Key, type: str) -> None:
         template = self.types.getTemplate(type)
         self.data[name] = template.copy()
 
-    def getType(self, name):
+    def getType(self, name: Key) -> Type:
         return self.data[name].type
 
-    def getValue(self, name):
+    def getValue(self, name: Key) -> Val:
         return self.data[name].value
 
-    def get(self, name):
+    def get(self, name: Key) -> "TypedValue":
         return self.data[name]
 
-    def setValue(self, name, value):
+    def setValue(self, name: Key, value: Any) -> None:
         self.data[name].value = value
 
-    def copy(self):
+    def copy(self) -> "Object":
         """This returns an empty copy of the object"""
         Class = type(self)
         newobj = Class(typesys=self.types)
@@ -256,17 +204,21 @@ class Frame(Object):
     lookup(name)
         returns the first frame containing the name
     """
-    def __init__(self, typesys, outer=None):
+    def __init__(
+        self,
+        typesys: "TypeSystem",
+        outer: "Frame"=None,
+    ) -> None:
         super().__init__(typesys=typesys)
         self.outer = outer
 
-    def set(self, name, typedValue):
+    def set(self, name, typedValue) -> None:
         self.data[name] = typedValue
 
-    def delete(self, name):
+    def delete(self, name) -> None:
         del self.data[name]
 
-    def lookup(self, name):
+    def lookup(self, name) -> "Frame":
         if self.has(name):
             return self
         if self.outer:
@@ -286,9 +238,109 @@ class Array(Object):
        The common type of each element
     """
     @property
-    def elementType(self):
+    def elementType(self) -> Type:
         for elem in self.data.values():
             return elem.type
+
+
+
+class Builtin(Value):
+    """
+    Represents a system function in pseudo.
+
+    Attributes
+    ----------
+    - params
+        A list of parameters used by the callable
+    - func
+        the Python function to call when invoked
+    """
+    __slots__ = ('params', 'func')
+    def __init__(
+        self,
+        params: Iterable,
+        func: function,
+    ) -> None:
+        self.params = params
+        self.func = func
+
+    def __repr__(self) -> str:
+        attrstr = ", ".join([
+            repr(getattr(self, attr)) for attr in self.__slots__
+        ])
+        return f'{type(self).__name__}({attrstr})'
+
+
+
+class Callable(Value):
+    """
+    Base class for Function and Procedure.
+    Represents a Callable in pseudo.
+
+    Attributes
+    ----------
+    - frame
+        The frame used by the callable
+    - params
+        A list of parameters used by the callable
+    - stmts
+        A list of statements the callable executes when called
+    """
+    __slots__ = ('frame', 'params', 'stmts')
+    def __init__(
+        self,
+        frame: "Frame",
+        params: Iterable[Param],
+        stmts: Iterable["Stmt"],
+    ) -> None:
+        self.frame = frame
+        self.params = params
+        self.stmts = stmts
+
+    def __repr__(self) -> str:
+        attrstr = ", ".join([
+            repr(getattr(self, attr)) for attr in self.__slots__
+        ])
+        return f'{type(self).__name__}({attrstr})'
+
+
+
+class Function(Callable):
+    """Functions are evaluated to return a value."""
+
+
+
+class Procedure(Callable):
+    """Procedures are called to execute its statements."""
+
+
+
+class File(Value):
+    """
+    Represents a file object in a frame.
+
+    Attributes
+    ----------
+    - name
+        Name of the file that is open
+    - mode
+        The mode that the file was opened in
+    - iohandler
+        An object for accessing the file
+    """
+    __slots__ = ('name', 'mode', 'iohandler')
+    def __init__(
+        self,
+        name: Name,
+        mode: str,
+        iohandler: TextIO,
+    ) -> None:
+        self.name = name
+        self.mode = mode
+        self.iohandler = iohandler
+
+    def __repr__(self) -> str:
+        return f"<{self.mode}: {self.name}>"
 
 
 
@@ -304,17 +356,20 @@ class Expr:
         Returns the token asociated with the expr, for error
         reporting purposes.
     """
-    def __init__(self, token=None):
+    def __init__(
+        self,
+        token: "Token"=None,
+    ) -> None:
         self._token = token
 
-    def token(self):
-        return self._token
-
-    def __repr__(self):
+    def __repr__(self) -> str:
         attrstr = ", ".join([
             repr(getattr(self, attr)) for attr in self.__slots__
         ])
         return f'{type(self).__name__}({attrstr})'
+
+    def token(self) -> "Token":
+        return self._token
 
 
 
@@ -328,7 +383,11 @@ class Literal(TypedValue, Expr):
 
 class Name(Expr):
     __slots__ = ('name',)
-    def __init__(self, name, token=None):
+    def __init__(
+        self,
+        name: Name,
+        token: "Token"=None,
+    ) -> None:
         super().__init__(token=token)
         self.name = name
 
@@ -336,7 +395,13 @@ class Name(Expr):
 
 class Declare(Expr):
     __slots__ = ('name', 'type', 'metadata')
-    def __init__(self, name, type, metadata=None, token=None):
+    def __init__(
+        self,
+        name: Name,
+        type: Type,
+        metadata: Mapping=None,
+        token: "Token"=None,
+    ) -> None:
         super().__init__(token=token)
         self.name = name
         self.type = type
@@ -346,7 +411,12 @@ class Declare(Expr):
 
 class Assign(Expr):
     __slots__ = ('name', 'assignee', 'expr')
-    def __init__(self, name, assignee, expr, token=None):
+    def __init__(
+        self,
+        name: Name,
+        assignee: "Get",
+        expr: "Expr",
+        token: "Token"=None) -> None:
         super().__init__(token=token)
         self.name = name
         self.assignee = assignee
@@ -356,7 +426,12 @@ class Assign(Expr):
 
 class Unary(Expr):
     __slots__ = ('oper', 'right')
-    def __init__(self, oper, right, token=None):
+    def __init__(
+        self,
+        oper: function,
+        right: "Expr",
+        token: "Token"=None,
+    ) -> None:
         super().__init__(token=token)
         self.oper = oper
         self.right = right
@@ -365,7 +440,13 @@ class Unary(Expr):
 
 class Binary(Expr):
     __slots__ = ('left', 'oper', 'right')
-    def __init__(self, left, oper, right, token=None):
+    def __init__(
+        self,
+        left: "Expr",
+        oper: function,
+        right: "Expr",
+        token: "Token"=None,
+    ) -> None:
         super().__init__(token=token)
         self.left = left
         self.oper = oper
@@ -375,7 +456,12 @@ class Binary(Expr):
 
 class Get(Expr):
     __slots__ = ('frame', 'name')
-    def __init__(self, frame, name, token=None):
+    def __init__(
+        self,
+        frame: "Frame",
+        name: Name,
+        token: "Token"=None,
+    ) -> None:
         super().__init__(token=token)
         self.frame = frame
         self.name = name
@@ -384,7 +470,12 @@ class Get(Expr):
 
 class Call(Expr):
     __slots__ = ('callable', 'args')
-    def __init__(self, callable, args, token=None):
+    def __init__(
+        self,
+        callable: "Callable",
+        args: Iterable[Arg],
+        token: "Token"=None,
+    ) -> None:
         super().__init__(token=token)
         self.callable = callable
         self.args = args
@@ -392,7 +483,7 @@ class Call(Expr):
 
 
 class Stmt:
-    def __repr__(self):
+    def __repr__(self) -> str:
         attrstr = ", ".join([
             repr(getattr(self, attr)) for attr in self.__slots__
         ])
@@ -402,7 +493,11 @@ class Stmt:
 
 class ExprStmt(Stmt):
     __slots__ = ('rule', 'expr')
-    def __init__(self, rule, expr):
+    def __init__(
+        self,
+        rule: Rule,
+        expr: "Expr",
+    ) -> None:
         self.rule = rule
         self.expr = expr
 
@@ -410,7 +505,11 @@ class ExprStmt(Stmt):
 
 class Output(Stmt):
     __slots__ = ('rule', 'exprs')
-    def __init__(self, rule, exprs):
+    def __init__(
+        self,
+        rule: Rule,
+        exprs: Iterable["Expr"],
+    ) -> None:
         self.rule = rule
         self.exprs = exprs
 
@@ -418,7 +517,11 @@ class Output(Stmt):
 
 class Input(Stmt):
     __slots__ = ('rule', 'name')
-    def __init__(self, rule, name):
+    def __init__(
+        self,
+        rule: Rule,
+        name: Name,
+    ) -> None:
         self.rule = rule
         self.name = name
 
@@ -426,7 +529,13 @@ class Input(Stmt):
 
 class Conditional(Stmt):
     __slots__ = ('rule', 'cond', 'stmtMap', 'fallback')
-    def __init__(self, rule, cond, stmtMap, fallback):
+    def __init__(
+        self,
+        rule: Rule,
+        cond: "Expr",
+        stmtMap: Mapping[Lit, "Stmt"],
+        fallback: "Stmt",
+    ) -> None:
         self.rule = rule
         self.cond = cond
         self.stmtMap = stmtMap
@@ -436,7 +545,13 @@ class Conditional(Stmt):
 
 class Loop(Stmt):
     __slots__ = ('rule', 'init', 'cond', 'stmts')
-    def __init__(self, rule, init, cond, stmts):
+    def __init__(
+        self,
+        rule: Rule,
+        init: "Stmt",
+        cond: "Expr",
+        stmts: Iterable["Stmt"],
+    ) -> None:
         self.rule = rule
         self.init = init
         self.cond = cond
@@ -446,7 +561,15 @@ class Loop(Stmt):
 
 class ProcFunc(Stmt):
     __slots__ = ('rule', 'name', 'passby', 'params', 'stmts', 'returnType')
-    def __init__(self, rule, name, passby, params, stmts, returnType):
+    def __init__(
+        self,
+        rule: Rule,
+        name: Name,
+        passby: str,
+        params: Iterable[Param],
+        stmts: Iterable["Stmt"],
+        returnType: Type,
+    ) -> None:
         self.rule = rule
         self.name = name
         self.passby = passby
@@ -458,7 +581,12 @@ class ProcFunc(Stmt):
 
 class TypeStmt(Stmt):
     __slots__ = ('rule', 'name', 'exprs')
-    def __init__(self, rule, name, exprs):
+    def __init__(
+        self,
+        rule: Rule,
+        name: Name,
+        exprs: Iterable["Expr"],
+    ) -> None:
         self.rule = rule
         self.name = name
         self.exprs = exprs
@@ -467,7 +595,14 @@ class TypeStmt(Stmt):
 
 class FileAction(Stmt):
     __slots__ = ('rule', 'action', 'name', 'mode', 'data')
-    def __init__(self, rule, action, name, mode, data):
+    def __init__(
+        self,
+        rule: Rule,
+        action: str,
+        name: Name,
+        mode: str,
+        data: "Expr",
+    ) -> None:
         self.rule = rule
         self.action = action
         self.name = name

--- a/pseudocode/lang.py
+++ b/pseudocode/lang.py
@@ -96,7 +96,6 @@ class TypedValue:
     Represents a value in 9608 pseudocode.
     Each TypedValue has a type and a value.
     """
-    __slots__ = ('type', 'value')
     def __init__(
         self,
         type: Type,
@@ -112,7 +111,9 @@ class TypedValue:
         return f"<{self.type}: {repr(self.value)}>"
 
     def copy(self) -> "TypedValue":
-        """This returns an empty copy of the typedvalue"""
+        """
+        This returns an empty copy of the typedvalue
+        """
         Class = type(self)
         if isinstance(self.value, Object):
             return Class(self.type, self.value.copy())
@@ -224,11 +225,12 @@ class Frame(Object):
     def delete(self, name) -> None:
         del self.data[name]
 
-    def lookup(self, name) -> "Frame":
+    def lookup(self, name) -> Optional["Frame"]:
         if self.has(name):
             return self
         if self.outer:
             return self.outer.lookup(name)
+        return None
 
 
 
@@ -337,7 +339,7 @@ class File(Value):
     __slots__ = ('name', 'mode', 'iohandler')
     def __init__(
         self,
-        name: Name,
+        name: Varname,
         mode: str,
         iohandler: TextIO,
     ) -> None:
@@ -353,16 +355,15 @@ class File(Value):
 class Expr:
     """
     Represents an expression in 9608 pseudocode.
-    An expression resolves to a type, and evaluates
-    to a value.
+    An expression can be resolved to a Type,
+    and evaluated to a Value.
+    An Expr must return an associated token for error-reporting purposes.
 
     Methods
     -------
-    - token() -> dict
-        Returns the token asociated with the expr, for error
-        reporting purposes.
+    - token() -> Token
+        Returns the token asociated with the expr
     """
-    __slots__ = NotImplemented
     def __init__(
         self,
         token: "Token",

--- a/pseudocode/lang.py
+++ b/pseudocode/lang.py
@@ -297,30 +297,18 @@ class Expr:
     Represents an expression in 9608 pseudocode.
     An expression resolves to a type, and evaluates
     to a value.
-    An Expr object has an accept() method which implements
-    the Visitor pattern.
 
     Methods
     -------
     - token() -> dict
         Returns the token asociated with the expr, for error
         reporting purposes.
-    - accept(frame, visitor) -> Any
-        Enables a visitor to carry out operations on the
-        Expr (with a provided frame).
-        The visitor should take in two arguments: a frame,
-        and an Expr.
     """
     def __init__(self, token=None):
         self._token = token
 
     def token(self):
         return self._token
-
-    def accept(self, frame, visitor, *args, **kwargs):
-        # visitor must be a function that takes
-        # a frame and an Expr
-        return visitor(frame, self, *args, **kwargs)
 
     def __repr__(self):
         attrstr = ", ".join([
@@ -404,11 +392,6 @@ class Call(Expr):
 
 
 class Stmt:
-    def accept(self, frame, visitor, *args, **kwargs):
-        # visitor must be a function that takes
-        # a frame and a Stmt
-        return visitor(frame, self, *args, **kwargs)
-
     def __repr__(self):
         attrstr = ", ".join([
             repr(getattr(self, attr)) for attr in self.__slots__

--- a/pseudocode/lang.py
+++ b/pseudocode/lang.py
@@ -1,16 +1,21 @@
 from typing import Any, Optional, Union, Iterable, Mapping
-from typing import Dict
+from typing import Tuple, Dict, NewType
 from typing import Callable as function, TextIO
 
 # Pseudocode types
-Type = str  # Built-in and declared types
-Varname = str  # Variable names
-Index = tuple  # Array indexes
-Key = Union[Name, Index]  # in TypedValue
+# Type represents a pseudocode type, whether built-in or declared
+Type = str
+# Varname represents a declared name
+Varname = str
+# Index represents array indexes used in Array
+Index = Tuple[int]
+# Key represents names that can be used in an Object
+# for storing values
+Key = Union[Varname, Index]  # in TypedValue
 Lit = Union[bool, int, float, str]  # Simple data types
-Val = Union[Lit, "Value", "Object"]  # in TypedValue
+Val = Union[Lit, "PseudoValue"]  # in TypedValue
 Param = Union["Get", "TypedValue"]  # Callable params
-Arg = "Expr"  # Call args
+Arg = NewType('Arg', "Expr")  # Call args
 Rule = str  # Stmt rules
 
 # ----------------------------------------------------------------------

--- a/pseudocode/lang.py
+++ b/pseudocode/lang.py
@@ -52,14 +52,14 @@ class TypeSystem:
 
     Methods
     -------
-    has(name)
+    has(type)
         returns True if the type has been declared, otherwise returns False
-    declare(name)
+    declare(type)
         declares the existence of a type
-    setTemplate(name, template)
+    setTemplate(type, template)
         set the template used to initialise a TypedValue with this type
-    getTemplate(name)
-        return the template of the type
+    cloneType(type)
+        return a copy of the template for the type
     """
     def __init__(
         self,
@@ -72,7 +72,7 @@ class TypeSystem:
 
     def __repr__(self) -> str:
         nameTypePairs = [
-            f"{name}: {self.getTemplate(name)}"
+            f"{name}: {self.data[name].value}"
             for name in self.data
         ]
         return f"{{{', '.join(nameTypePairs)}}}"
@@ -83,11 +83,14 @@ class TypeSystem:
     def declare(self, name: str) -> None:
         self.data[name] = TypedValue(name, None)
 
-    def setTemplate(self, name: str, template: Optional["Object"]) -> None:
+    def setTemplate(self, name: Type, template: Optional["Object"]) -> None:
         self.data[name].value = template
 
-    def getTemplate(self, name) -> Optional[Val]:
-        return self.data[name].value
+    def clone(self, name: Type) -> Optional["Object"]:
+        template = self.data[name].value
+        if template:
+            return template.copy()
+        return template
 
 
 
@@ -171,8 +174,8 @@ class Object(Value):
         return name in self.data
 
     def declare(self, name: Key, type: str) -> None:
-        template = self.types.getTemplate(type)
-        self.data[name] = template.copy()
+        self.data[name] = TypedValue(type, None)
+        self.data[name].value = self.types.clone(type)
 
     def getType(self, name: Key) -> Type:
         return self.data[name].type

--- a/pseudocode/parser.py
+++ b/pseudocode/parser.py
@@ -28,7 +28,7 @@ def makeExpr(
     type: lang.Type=None,
     value:lang.Val=None,
     frame: lang.Object=None,
-    name: lang.Name=None,
+    name: lang.Varname=None,
     assignee: Union[lang.Object, lang.Expr]=None,
     expr: lang.Expr=None,
     left: lang.Expr=None,

--- a/pseudocode/parser.py
+++ b/pseudocode/parser.py
@@ -118,7 +118,7 @@ def matchTypeElseError(
 # 5. <> | =
 # 6. AND | OR
 
-def identifier(tokens: Tokens) -> Optional[lang.Expr]:
+def identifier(tokens: Tokens) -> Optional[lang.Name]:
     if expectType(tokens, 'name'):
         token = consume(tokens)
         return makeExpr(name=token.word, token=token)

--- a/pseudocode/parser.py
+++ b/pseudocode/parser.py
@@ -1,98 +1,113 @@
-from .builtin import TYPES, NULL
-from .builtin import ParseError
-from .builtin import lte, add
-from .lang import Token
-from .lang import Literal, Name, Unary, Binary, Get, Call, Assign
-from .lang import ExprStmt, Output, Input, Declare
-from .lang import Conditional, Loop, ProcFunc, TypeStmt, FileAction
+from typing import Union, Optional
+from typing import Iterable, Tuple, Mapping, Callable as function
+
+from . import builtin, lang
+
+Tokens = Iterable[lang.Token]
 
 
 
 # Helper functions
 
-def atEnd(tokens):
+def atEnd(tokens: Tokens):
     return check(tokens).type == 'EOF'
 
-def atEndThenError(tokens):
+def atEndThenError(tokens: Tokens):
     if atEnd(tokens):
-        raise ParseError("Unexpected EOF", check(tokens))
+        raise builtin.ParseError("Unexpected EOF", check(tokens))
 
-def check(tokens):
+def check(tokens: Tokens):
     return tokens[0]
 
-def consume(tokens):
+def consume(tokens: Tokens):
     token = tokens.pop(0)
     return token
 
 def makeExpr(
     *,
-    type=None, value=None,
-    frame=None, name=None, assignee=None, expr=None,
-    left=None, oper=None, right=None,
-    callable=None, args=None,
-    token=None, metadata=None,
-):
+    type: lang.Type=None,
+    value:lang.Val=None,
+    frame: lang.Object=None,
+    name: lang.Name=None,
+    assignee: Union[lang.Object, lang.Expr]=None,
+    expr: lang.Expr=None,
+    left: lang.Expr=None,
+    oper: function=None,
+    right: lang.Expr=None,
+    callable: lang.Callable=None,
+    args: Iterable[lang.Arg]=None,
+    token: lang.Token=None,
+    metadata: Mapping=None,
+) -> lang.Expr:
     if name is not None:
         if frame is not None:
-            return Get(frame, name, token=token)
+            return lang.Get(frame, name, token=token)
         elif expr is not None:
             if assignee is None:
                 assignee = name
-            return Assign(name, assignee, expr, token=token)
+            return lang.Assign(name, assignee, expr, token=token)
         elif type is not None:
-            return Declare(name, type, metadata, token=token)
+            return lang.Declare(name, type, metadata, token=token)
         else:
-            return Name(name, token=token)
+            return lang.Name(name, token=token)
     if type is not None and value is not None:
-        return Literal(type, value, token=token)
+        return lang.Literal(type, value, token=token)
     if oper is not None and right is not None:
         if left is not None:
-            return Binary(left, oper, right, token=token)
+            return lang.Binary(left, oper, right, token=token)
         else:
-            return Unary(oper, right, token=token)
+            return lang.Unary(oper, right, token=token)
     if callable is not None and args is not None:
-        return Call(callable, args, token=token)
+        return lang.Call(callable, args, token=token)
     raise ValueError(
         "Could not find valid keyword argument combination"
     )
 
-def expectWord(tokens, *words):
+def expectWord(tokens: Tokens, *words: str) -> Optional[lang.Token]:
     if check(tokens).word in words:
         return check(tokens)
     atEndThenError(tokens)
     return None
 
-def expectType(tokens, *types):
+def expectType(tokens: Tokens, *types: lang.Type) -> Optional[lang.Token]:
     if check(tokens).type in types:
         return check(tokens)
     atEndThenError(tokens)
     return None
 
-def matchWord(tokens, *words):
+def matchWord(tokens: Tokens, *words: str) -> Optional[lang.Token]:
     if check(tokens).word in words:
         return consume(tokens)
     atEndThenError(tokens)
     return None
 
-def matchType(tokens, *types):
+def matchType(tokens: Tokens, *types: lang.Type) -> Optional[lang.Token]:
     if check(tokens).type in types:
         return consume(tokens)
     atEndThenError(tokens)
     return None
 
-def matchWordElseError(tokens, *words, msg=''):
+def matchWordElseError(
+    tokens: Tokens,
+    *words: str,
+    msg: str='',
+) -> Optional[lang.Token]:
     token = matchWord(tokens, *words)
     if token:
         return token
     msg = f"Expected {words}" + (f' {msg}' if msg else '')
-    raise ParseError(msg, check(tokens))
+    raise builtin.ParseError(msg, check(tokens))
 
-def matchTypeElseError(tokens, *types, msg=''):
+def matchTypeElseError(
+    tokens: Tokens,
+    *types: lang.Type,
+        msg: str='',
+) -> Optional[lang.Token]:
     token = matchType(tokens, *types)
     if token:
         return token
     msg = f"Expected {types}" + (f' {msg}' if msg else '')
-    raise ParseError(msg, check(tokens))
+    raise builtin.ParseError(msg, check(tokens))
 
 # Precedence parsers
 # Expressions are parsed with this precedence (highest to lowest):
@@ -103,13 +118,13 @@ def matchTypeElseError(tokens, *types, msg=''):
 # 5. <> | =
 # 6. AND | OR
 
-def identifier(tokens):
+def identifier(tokens: Tokens) -> Optional[lang.Expr]:
     if expectType(tokens, 'name'):
         token = consume(tokens)
         return makeExpr(name=token.word, token=token)
-    raise ParseError(f"Expected variable name", consume(tokens))
+    raise builtin.ParseError(f"Expected variable name", consume(tokens))
 
-def literal(tokens):
+def literal(tokens: Tokens) -> lang.Expr:
     token = consume(tokens)
     return makeExpr(
         type=token.type,
@@ -117,7 +132,7 @@ def literal(tokens):
         token=token,
     )
 
-def unary(tokens):
+def unary(tokens: Tokens) -> lang.Expr:
     oper = consume(tokens)
     right = value(tokens)
     return makeExpr(
@@ -126,15 +141,15 @@ def unary(tokens):
         token=oper,
     )
 
-def name(tokens):
+def name(tokens: Tokens) -> lang.Expr:
     iden = identifier(tokens)
     return makeExpr(
-        frame=NULL,
+        frame=builtin.NULL,
         name=iden.name,
         token=iden.token(),
     )
 
-def callExpr(tokens, expr):
+def callExpr(tokens: Tokens, expr: lang.Expr) -> lang.Expr:
     args = []
     argcount = 0
     while not expectWord(tokens, ')'):
@@ -150,7 +165,7 @@ def callExpr(tokens, expr):
         token=name.token(),
     )
 
-def attrExpr(tokens, expr):
+def attrExpr(tokens: Tokens, expr: lang.Expr) -> lang.Expr:
     name = identifier(tokens)
     return makeExpr(
         frame=expr,
@@ -158,7 +173,7 @@ def attrExpr(tokens, expr):
         token=name.token(),
     )
 
-def arrayExpr(tokens, expr):
+def arrayExpr(tokens: Tokens, expr: lang.Expr) -> lang.Expr:
     index = (expression(tokens),)
     while matchWord(tokens, ','):
         index += (expression(tokens),)
@@ -169,7 +184,7 @@ def arrayExpr(tokens, expr):
         token=expr.token(),
     )
 
-def value(tokens):
+def value(tokens: Tokens) -> lang.Expr:
     token = check(tokens)
     # Unary expressions
     if expectWord(tokens, '-', 'NOT'):
@@ -180,7 +195,7 @@ def value(tokens):
         matchWordElseError(tokens, ')', msg="after '('")
         return expr
     # A single value
-    if expectType(tokens, *TYPES):
+    if expectType(tokens, *builtin.TYPES):
         return literal(tokens)
     # A name or call or attribute
     if expectType(tokens, 'name'):
@@ -197,9 +212,9 @@ def value(tokens):
                 expr = attrExpr(tokens, expr)
         return expr
     else:
-        raise ParseError("Unexpected token", token)
+        raise builtin.ParseError("Unexpected token", token)
 
-def muldiv(tokens):
+def muldiv(tokens: Tokens) -> lang.Binary:
     # *, /
     expr = value(tokens)
     while expectWord(tokens, '*', '/'):
@@ -213,7 +228,7 @@ def muldiv(tokens):
         )
     return expr
 
-def addsub(tokens):
+def addsub(tokens: Tokens) -> lang.Binary:
     expr = muldiv(tokens)
     while expectWord(tokens, '+', '-'):
         oper = consume(tokens)
@@ -226,7 +241,7 @@ def addsub(tokens):
         )
     return expr
 
-def comparison(tokens):
+def comparison(tokens: Tokens) -> lang.Binary:
     # <, <=, >, >=
     expr = addsub(tokens)
     while expectWord(tokens, '<', '<=', '>', '>='):
@@ -240,7 +255,7 @@ def comparison(tokens):
         )
     return expr
 
-def equality(tokens):
+def equality(tokens: Tokens) -> lang.Binary:
     # <>, =
     expr = comparison(tokens)
     while expectWord(tokens, '<>', '='):
@@ -254,7 +269,7 @@ def equality(tokens):
         )
     return expr
 
-def logical(tokens):
+def logical(tokens: Tokens) -> lang.Binary:
     # AND, OR
     expr = equality(tokens)
     while expectWord(tokens, 'AND', 'OR'):
@@ -268,11 +283,11 @@ def logical(tokens):
         )
     return expr
 
-def expression(tokens):
+def expression(tokens: Tokens) -> lang.Expr:
     expr = logical(tokens)
     return expr
 
-def assignment(tokens):
+def assignment(tokens: Tokens) -> lang.Assign:
     assignee = name(tokens)  # Get Expr
     while expectWord(tokens, '[', '.'):
         # Array get
@@ -292,29 +307,29 @@ def assignment(tokens):
 
 # Statement parsers
 
-def outputStmt(tokens):
+def outputStmt(tokens: Tokens) -> lang.Output:
     exprs = [expression(tokens)]
     while matchWord(tokens, ','):
         exprs += [expression(tokens)]
     matchWordElseError(tokens, '\n', msg="after statement")
-    return Output('output', exprs)
+    return lang.Output('output', exprs)
 
-def inputStmt(tokens):
+def inputStmt(tokens: Tokens) -> lang.Input:
     name = identifier(tokens)
     matchWordElseError(tokens, '\n', msg="after statement")
-    return Input('input', name)
+    return lang.Input('input', name)
 
-def colonRange(tokens):
+def colonRange(tokens: Tokens) -> Tuple[int]:
     """Parse and return a start:end range as a tuple"""
     range_start = matchTypeElseError(tokens, 'INTEGER')
     matchWordElseError(tokens, ':', msg="in range")
     range_end = matchTypeElseError(tokens, 'INTEGER')
     return (range_start.value, range_end.value)
 
-def declare(tokens):
-    def expectTypeToken(tokens):
-        if not (expectWord(tokens, *TYPES) or expectType(tokens, 'name')):
-            raise ParseError("Invalid type", check(tokens))
+def declare(tokens: Tokens) -> lang.Declare:
+    def expectTypeToken(tokens: Tokens):
+        if not (expectWord(tokens, *builtin.TYPES) or expectType(tokens, 'name')):
+            raise builtin.ParseError("Invalid type", check(tokens))
         
     name = identifier(tokens)
     matchWordElseError(tokens, ':', msg="after name")
@@ -337,12 +352,12 @@ def declare(tokens):
         token=name.token(),
     )
     
-def declareStmt(tokens):
+def declareStmt(tokens: Tokens) -> lang.ExprStmt:
     expr = declare(tokens)
     matchWordElseError(tokens, '\n', msg="after statement")
-    return ExprStmt('declare', expr)
+    return lang.ExprStmt('declare', expr)
 
-def typeStmt(tokens):
+def typeStmt(tokens: Tokens) -> lang.TypeStmt:
     name = identifier(tokens)
     matchWordElseError(tokens, '\n')
     exprs = []
@@ -352,14 +367,14 @@ def typeStmt(tokens):
         matchWordElseError(tokens, '\n')
     matchWordElseError(tokens, 'ENDTYPE')
     matchWordElseError(tokens, '\n')
-    return TypeStmt('declaretype', name.name, exprs)
+    return lang.TypeStmt('declaretype', name.name, exprs)
 
-def assignStmt(tokens):
+def assignStmt(tokens: Tokens) -> lang.ExprStmt:
     expr = assignment(tokens)
     matchWordElseError(tokens, '\n', msg="after statement")
-    return ExprStmt('assign', expr)
+    return lang.ExprStmt('assign', expr)
 
-def caseStmt(tokens):
+def caseStmt(tokens: Tokens) -> lang.Conditional:
     matchWordElseError(tokens, 'OF', msg="after CASE")
     cond = value(tokens)
     matchWordElseError(tokens, '\n', msg="after CASE OF")
@@ -374,9 +389,9 @@ def caseStmt(tokens):
         fallback = statement6(tokens)
     matchWordElseError(tokens, 'ENDCASE', msg="at end of CASE")
     matchWordElseError(tokens, '\n', msg="after ENDCASE")
-    return Conditional('case', cond, stmts, fallback)
+    return lang.Conditional('case', cond, stmts, fallback)
 
-def ifStmt(tokens):
+def ifStmt(tokens: Tokens) -> lang.Conditional:
     cond = expression(tokens)
     matchWord(tokens, '\n')  # optional line break
     matchWordElseError(tokens, 'THEN')
@@ -393,9 +408,9 @@ def ifStmt(tokens):
         fallback = false
     matchWordElseError(tokens, 'ENDIF', msg="at end of IF")
     matchWordElseError(tokens, '\n', msg="after statement")
-    return Conditional('if', cond, stmts, fallback)
+    return lang.Conditional('if', cond, stmts, fallback)
 
-def whileStmt(tokens):
+def whileStmt(tokens: Tokens) -> lang.Loop:
     cond = expression(tokens)
     matchWordElseError(tokens, 'DO', msg="after WHILE condition")
     matchWordElseError(tokens, '\n', msg="after DO")
@@ -403,18 +418,18 @@ def whileStmt(tokens):
     while not matchWord(tokens, 'ENDWHILE'):
         stmts += [statement5(tokens)]
     matchWordElseError(tokens, '\n', msg="after ENDWHILE")
-    return Loop('while', None, cond, stmts)
+    return lang.Loop('while', None, cond, stmts)
 
-def repeatStmt(tokens):
+def repeatStmt(tokens: Tokens) -> lang.Loop:
     matchWordElseError(tokens, '\n', msg="after REPEAT")
     stmts = []
     while not matchWord(tokens, 'UNTIL'):
         stmts += [statement5(tokens)]
     cond = expression(tokens)
     matchWordElseError(tokens, '\n', msg="at end of UNTIL")
-    return Loop('repeat', None, cond, stmts)
+    return lang.Loop('repeat', None, cond, stmts)
 
-def forStmt(tokens):
+def forStmt(tokens: Tokens) -> lang.Loop:
     init = assignment(tokens)
     matchWordElseError(tokens, 'TO')
     end = value(tokens)
@@ -428,13 +443,13 @@ def forStmt(tokens):
     matchWordElseError(tokens, '\n', msg="after ENDFOR")
     # Generate loop cond
     getCounter = makeExpr(
-        frame=NULL,
+        frame=builtin.NULL,
         name=init.name,
         token=init.token(),
     )
     cond = makeExpr(
         left=getCounter,
-        oper=lte,
+        oper=builtin.lte,
         right=end,
         token=init.token(),
     )
@@ -444,17 +459,17 @@ def forStmt(tokens):
         assignee=init.assignee,
         expr=makeExpr(
             left=getCounter,
-            oper=add,
+            oper=builtin.add,
             right=step,
             token=step.token(),
         ),
         token=init.token(),
     )
-    initStmt = ExprStmt('assign', init)
-    incrStmt = ExprStmt('assign', incr)
-    return Loop('while', initStmt, cond, stmts + [incrStmt])
+    initStmt = lang.ExprStmt('assign', init)
+    incrStmt = lang.ExprStmt('assign', incr)
+    return lang.Loop('while', initStmt, cond, stmts + [incrStmt])
 
-def procedureStmt(tokens):
+def procedureStmt(tokens: Tokens) -> lang.ProcFunc:
     name = identifier(tokens).name
     params = []
     if matchWord(tokens, '('):
@@ -472,14 +487,14 @@ def procedureStmt(tokens):
     while not matchWord(tokens, 'ENDPROCEDURE'):
         stmts += [statement3(tokens)]
     matchWordElseError(tokens, '\n', msg="after ENDPROCEDURE")
-    return ProcFunc('procedure', name, passby, params, stmts, 'NULL')
+    return lang.ProcFunc('procedure', name, passby, params, stmts, 'NULL')
 
-def callStmt(tokens):
+def callStmt(tokens: Tokens) -> lang.ExprStmt:
     callable = value(tokens)
     matchWordElseError(tokens, '\n', msg="at end of CALL")
-    return ExprStmt('call', callable)
+    return lang.ExprStmt('call', callable)
 
-def functionStmt(tokens):
+def functionStmt(tokens: Tokens) -> lang.ProcFunc:
     name = identifier(tokens).name
     params = []
     if matchWord(tokens, '('):
@@ -491,48 +506,48 @@ def functionStmt(tokens):
             params += [var]
         matchWordElseError(tokens, ')', msg="at end of parameters")
     matchWordElseError(tokens, 'RETURNS', msg="after parameters")
-    typetoken = matchWordElseError(tokens, *TYPES, msg="Invalid type")
+    typetoken = matchWordElseError(tokens, *builtin.TYPES, msg="Invalid type")
     matchWordElseError(tokens, '\n', msg="at end of FUNCTION")
     stmts = []
     while not matchWord(tokens, 'ENDFUNCTION'):
         stmts += [statement3(tokens)]
     matchWordElseError(tokens, '\n', msg="after ENDFUNCTION")
-    return ProcFunc(
+    return lang.ProcFunc(
         'function', name, passby, params, stmts, typetoken.word
     )
 
-def returnStmt(tokens):
+def returnStmt(tokens: Tokens) -> lang.ExprStmt:
     expr = expression(tokens)
     matchWordElseError(tokens, '\n', msg="at end of RETURN")
-    return ExprStmt('return', expr)
+    return lang.ExprStmt('return', expr)
 
-def openfileStmt(tokens):
+def openfileStmt(tokens: Tokens) -> lang.FileAction:
     name = value(tokens)
     matchWordElseError(tokens, 'FOR', msg="after file identifier")
     mode = matchWordElseError(
         tokens, 'READ', 'WRITE', 'APPEND', msg="Invalid file mode"
     )
     matchWordElseError(tokens, '\n')
-    return FileAction('file', 'open', name, mode, None)
+    return lang.FileAction('file', 'open', name, mode, None)
 
-def readfileStmt(tokens):
+def readfileStmt(tokens: Tokens) -> lang.FileAction:
     name = value(tokens)
     matchWordElseError(tokens, ',', msg="after file identifier")
     data = identifier(tokens)
     matchWordElseError(tokens, '\n')
-    return FileAction('file', 'read', name, None, data.name)
+    return lang.FileAction('file', 'read', name, None, data.name)
 
-def writefileStmt(tokens):
+def writefileStmt(tokens: Tokens) -> lang.FileAction:
     name = value(tokens)
     matchWordElseError(tokens, ',', msg="after file identifier")
     data = expression(tokens)
     matchWordElseError(tokens, '\n')
-    return FileAction('file', 'write', name, None, data)
+    return lang.FileAction('file', 'write', name, None, data)
 
-def closefileStmt(tokens):
+def closefileStmt(tokens: Tokens) -> lang.FileAction:
     name = value(tokens)
     matchWordElseError(tokens, '\n')
-    return FileAction('file', 'close', name, None, None)
+    return lang.FileAction('file', 'close', name, None, None)
 
 # Statement hierarchy
 # Statements are parsed in this order (most to least restrictive):
@@ -550,26 +565,26 @@ def closefileStmt(tokens):
 # 6. OUTPUT | INPUT | CALL | Assign | OPEN/READ/WRITE/CLOSEFILE
 #    may be used anywhere in a program
 
-def statement1(tokens):
+def statement1(tokens: Tokens) -> lang.Stmt:
     if matchWord(tokens, 'RETURN'):
         return returnStmt(tokens)
     return statement3(tokens)
 
-def statement2(tokens):
+def statement2(tokens: Tokens) -> lang.Stmt:
     if matchWord(tokens, 'FUNCTION'):
         return functionStmt(tokens)
     if matchWord(tokens, 'PROCEDURE'):
         return procedureStmt(tokens)
     return statement3(tokens)
 
-def statement3(tokens):
+def statement3(tokens: Tokens) -> lang.Stmt:
     if matchWord(tokens, 'DECLARE'):
         return declareStmt(tokens)
     if matchWord(tokens, 'TYPE'):
         return typeStmt(tokens)
     return statement4(tokens)
 
-def statement4(tokens):
+def statement4(tokens: Tokens) -> lang.Stmt:
     if matchWord(tokens, 'IF'):
         return ifStmt(tokens)
     if matchWord(tokens, 'WHILE'):
@@ -580,12 +595,12 @@ def statement4(tokens):
         return forStmt(tokens)
     return statement5(tokens)
 
-def statement5(tokens):
+def statement5(tokens: Tokens) -> lang.Stmt:
     if matchWord(tokens, 'CASE'):
         return caseStmt(tokens)
     return statement6(tokens)
 
-def statement6(tokens):
+def statement6(tokens: Tokens) -> lang.Stmt:
     if matchWord(tokens, 'OUTPUT'):
         return outputStmt(tokens)
     if matchWord(tokens, 'INPUT'):
@@ -602,13 +617,13 @@ def statement6(tokens):
         return closefileStmt(tokens)
     if expectType(tokens, 'name'):
         return assignStmt(tokens)
-    raise ParseError("Unrecognised token", check(tokens))
+    raise builtin.ParseError("Unrecognised token", check(tokens))
 
 # Main parsing loop
 
-def parse(tokens):
+def parse(tokens: Tokens) -> Iterable[lang.Stmt]:
     lastline = tokens[-1].line
-    tokens += [Token(lastline, 0, 'EOF', "", None)]
+    tokens += [lang.Token(lastline, 0, 'EOF', "", None)]
     statements = []
     while not atEnd(tokens):
         while matchWord(tokens, '\n'):

--- a/pseudocode/parser.py
+++ b/pseudocode/parser.py
@@ -9,17 +9,17 @@ Tokens = Iterable[lang.Token]
 
 # Helper functions
 
-def atEnd(tokens: Tokens):
+def atEnd(tokens: Tokens) -> bool:
     return check(tokens).type == 'EOF'
 
-def atEndThenError(tokens: Tokens):
+def atEndThenError(tokens: Tokens) -> None:
     if atEnd(tokens):
         raise builtin.ParseError("Unexpected EOF", check(tokens))
 
-def check(tokens: Tokens):
+def check(tokens: Tokens) -> lang.Token:
     return tokens[0]
 
-def consume(tokens: Tokens):
+def consume(tokens: Tokens) -> lang.Token:
     token = tokens.pop(0)
     return token
 

--- a/pseudocode/resolver.py
+++ b/pseudocode/resolver.py
@@ -183,7 +183,7 @@ def resolveObj(
         errmsg="Undeclared type", token=token
     )
     # Check attribute existence in object template
-    objTemplate = typesystem.getTemplate(objType).value
+    objTemplate = typesystem.getTemplate(objType)
     declaredElseError(
         objTemplate, name,
         errmsg="Undeclared attribute", token=token

--- a/pseudocode/resolver.py
+++ b/pseudocode/resolver.py
@@ -26,7 +26,7 @@ def expectTypeElseError(
 
 def declaredElseError(
     frame: lang.Frame,
-    name: lang.Name,
+    name: lang.Varname,
     errmsg: str="Undeclared",
     declaredType: lang.Type=None,
     *,
@@ -173,7 +173,7 @@ def resolveAssign(
 def resolveObj(
     typesystem: lang.TypeSystem,
     objType: lang.Type,
-    name: lang.Name,
+    name: lang.Varname,
     *,
     token: lang.Token,
 ) -> lang.Type:

--- a/pseudocode/resolver.py
+++ b/pseudocode/resolver.py
@@ -423,4 +423,4 @@ def verify(frame: lang.Frame, stmt) -> Optional[lang.Type]:
     elif stmt.rule in ('assign', 'declare', 'return'):
         return resolve(frame, stmt.expr)
     elif stmt.rule == 'call':
-        resolveProcCall(frame, stmt.expr)
+        return resolveProcCall(frame, stmt.expr)

--- a/pseudocode/resolver.py
+++ b/pseudocode/resolver.py
@@ -401,7 +401,7 @@ def verifyDeclareType(frame: lang.Frame, stmt: lang.Stmt) -> None:
     
 
 
-def verify(frame: lang.Frame, stmt) -> Optional[lang.Type]:
+def verify(frame: lang.Frame, stmt: lang.stmt) -> Optional[lang.Type]:
     if stmt.rule == 'output':
         verifyOutput(frame, stmt)
     if stmt.rule == 'input':

--- a/pseudocode/resolver.py
+++ b/pseudocode/resolver.py
@@ -101,7 +101,7 @@ def resolveDeclare(frame, expr, passby='BYVALUE'):
     frame.set(expr.name, frame.outer.get(expr.name))
 
 def resolveUnary(frame, expr):
-    rType = expr.right.accept(frame, resolve)
+    rType = resolve(frame, expr.right)
     if expr.oper is sub:
         expectTypeElseError(rType, *NUMERIC, token=expr.right.token())
         return rType
@@ -209,7 +209,7 @@ def resolveGet(frame, expr):
     return frame.getType(expr.name)
 
 def resolveProcCall(frame, expr):
-    expr.callable.accept(frame, resolveGet)
+    resolveGet(frame, expr.callable)
     # Resolve global frame where procedure is declared
     callFrame = expr.callable.frame
     callable = callFrame.getValue(expr.callable.name)

--- a/pseudocode/resolver.py
+++ b/pseudocode/resolver.py
@@ -71,6 +71,10 @@ def resolveExprs(frame, exprs):
     for expr in exprs:
         resolve(frame, expr)
 
+def evalLiteral(frame, expr):
+    """Return the value of a Literal"""
+    return expr.value
+    
 def resolveLiteral(frame, literal):
     return literal.type
 
@@ -291,7 +295,7 @@ def verifyIf(frame, stmt):
 
 def verifyLoop(frame, stmt):
     if stmt.init:
-        verifyAssign(frame, stmt.init)
+        resolve(frame, stmt.init)
     condType = resolve(frame, stmt.cond)
     expectTypeElseError(condType, 'BOOLEAN', token=stmt.cond.token())
     verifyStmts(frame, stmt.stmts)
@@ -330,7 +334,7 @@ def verifyFunction(frame, stmt):
     verifyStmts(local, stmt.stmts)
 
 def verifyFile(frame, stmt):
-    value(frame, stmt.name)
+    evalLiteral(frame, stmt.name)
     if stmt.action == 'open':
         pass
     elif stmt.action in ('read', 'write'):

--- a/pseudocode/resolver.py
+++ b/pseudocode/resolver.py
@@ -183,7 +183,7 @@ def resolveObj(
         errmsg="Undeclared type", token=token
     )
     # Check attribute existence in object template
-    objTemplate = typesystem.getTemplate(objType)
+    objTemplate = typesystem.clone(objType)
     declaredElseError(
         objTemplate, name,
         errmsg="Undeclared attribute", token=token
@@ -392,11 +392,11 @@ def verifyFile(frame: lang.Frame, stmt: lang.FileAction) -> None:
     elif stmt.action == 'close':
         pass
 
-def verifyDeclareType(frame: lang.Frame, stmt: lang.Stmt) -> None:
+def verifyDeclareType(frame: lang.Frame, stmt: lang.TypeStmt) -> None:
     frame.types.declare(stmt.name)
     obj = lang.Object(typesys=frame.types)
     for expr in stmt.exprs:
-        resolveDeclare(obj, expr)
+        resolve(obj, expr)
     frame.types.setTemplate(stmt.name, obj)
     
 

--- a/pseudocode/resolver.py
+++ b/pseudocode/resolver.py
@@ -43,6 +43,13 @@ def declaredElseError(
             frame.getType(name), declaredType, token=token
         )
 
+def rangeProduct(indexes):
+    ranges = [
+        range(start, end + 1)
+        for (start, end) in indexes
+    ]
+    return product(*ranges)
+
 
 
 class Resolver:
@@ -77,11 +84,7 @@ def resolveDeclare(frame, expr, passby='BYVALUE'):
             # itertools.product takes n iterables and returns
             # cartesian product of its combinations
             elemType = expr.metadata['type']
-            ranges = [
-                range(start, end + 1)
-                for (start, end) in expr.metadata['size']
-            ]
-            for index in product(*ranges):
+            for index in rangeProduct(expr.metadata['size']):
                 array.declare(index, elemType)
             frame.setValue(expr.name, array)
         return expr.type

--- a/pseudocode/resolver.py
+++ b/pseudocode/resolver.py
@@ -401,7 +401,7 @@ def verifyDeclareType(frame: lang.Frame, stmt: lang.Stmt) -> None:
     
 
 
-def verify(frame: lang.Frame, stmt: lang.stmt) -> Optional[lang.Type]:
+def verify(frame: lang.Frame, stmt: lang.Stmt) -> Optional[lang.Type]:
     if stmt.rule == 'output':
         verifyOutput(frame, stmt)
     if stmt.rule == 'input':

--- a/pseudocode/scanner.py
+++ b/pseudocode/scanner.py
@@ -1,7 +1,7 @@
-from typing import Sequence, Iterable, Mapping
+from typing import Iterable, Tuple, Mapping
 Code = Mapping
 
-import builtin
+from . import builtin
 from .lang import Token, Type, Lit
 
 
@@ -71,7 +71,7 @@ def symbol(code: Code) -> str:
 
 # Main scanning loop
 
-def scan(src: str) -> Sequence[Iterable[Token], Iterable[str]]:
+def scan(src: str) -> Tuple[Iterable]:
     if not src.endswith('\n'):
         src = src + '\n'
     code = {

--- a/pseudocode/system.py
+++ b/pseudocode/system.py
@@ -1,3 +1,4 @@
+from typing import TextIO
 import random
 
 from .builtin import TYPES, RuntimeError
@@ -9,7 +10,7 @@ system = Frame(typesys=TypeSystem(*TYPES))
 
 
 
-def RND():
+def RND() -> float:
     return random.random()
 system.declare('RND', 'REAL')
 system.setValue('RND', Builtin(
@@ -17,7 +18,7 @@ system.setValue('RND', Builtin(
     func=RND,
 ))
 
-def RANDOMBETWEEN(start, end):
+def RANDOMBETWEEN(start: int, end: int) -> int:
     if not (start < end):
         raise RuntimeError(f"{start} not less than {end}", None)
     return random.randint(start, end)
@@ -30,7 +31,7 @@ system.setValue('RANDOMBETWEEN', Builtin(
     func=RANDOMBETWEEN,
 ))
 
-def EOF(file):
+def EOF(file: TextIO) -> bool:
     # Python has no in-built EOF support;
     # if read() or readline() return an empty string,
     # that's considered EOF

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
+mypy = "^0.950"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
With 80% feature completion, I'm not expecting much changes to the code at this point. That means we can start to lock down the interfaces and app design for more stability.

But first, some inconsequential edits, mostly for readability: [fe90aeddeeeff7a762ce1e50becfe7d2dc1dc811], [37490dc51e6ca09fe7ef194c035037e78d96f326], [95782cd76e0fac09d860041ef88b6e7c310c2ec1], [12da110f17b363670b861037ea4fa17de3313f39], [01cbeb8c56d0538864790b1355ed8c7d76f7b84a]

A fix for a bug introduced during cleanup: [ff2da2a6c5338771d43f7d8744feefe7b9a009dc]

And another helper to help us iterate through combinations of indexes for declaring arrays: [70899ab3574843c38cdcc2691abb4abe80aa2f5b]

Finally, a fix in error reporting: [58283ed08fcdfcc380c0a1f391aef4bd0cddfa9f]