### PR TITLE
26c Release: Logging

### DIFF
--- a/pseudocode/__init__.py
+++ b/pseudocode/__init__.py
@@ -28,7 +28,7 @@ class Result(TypedDict):
 
 
 
-__version__ = '0.4.0'
+__version__ = '0.4.1'
 VERSION = f"Pseudo {__version__}"
 HELP = """
 usage: pseudo [option] ... file

--- a/pseudocode/__init__.py
+++ b/pseudocode/__init__.py
@@ -1,7 +1,7 @@
 from typing import Optional
 from typing import Iterable, List, MutableMapping
 from typing import TypedDict, Callable as function
-import os, sys, traceback
+import os, sys
 
 import logging
 logging.basicConfig(
@@ -38,13 +38,8 @@ file   : program read from script file
 
 
 def logException() -> None:
-    logging.exception()
-
-# https://stackoverflow.com/a/66416364/318186
-def printException() -> None:
-    etype, value, tb = sys.exc_info()
-    info, error = traceback.format_exception(etype, value, tb)[-2:]
-    print(f'Exception in:\n{info}\n{error}')
+    # https://docs.python.org/3.8/library/logging.html#logging.Logger.exception
+    logging.exception("Unexpected error has occurred")
 
 def report(lines: Iterable[str], err: builtin.PseudoError) -> None:
     errType = type(err).__name__ + ':'

--- a/pseudocode/__init__.py
+++ b/pseudocode/__init__.py
@@ -3,6 +3,13 @@ from typing import Iterable, List, MutableMapping
 from typing import TypedDict, Callable as function
 import os, sys, traceback
 
+import logging
+logging.basicConfig(
+    filename='pseudo.log',
+    filemode='w',
+    format='%(name)s - %(levelname)s - %(message)s',
+)
+
 from . import builtin
 from .lang import Frame
 from .system import system as sysFrame
@@ -29,6 +36,9 @@ file   : program read from script file
 """.strip()
 
 
+
+def logException() -> None:
+    logging.exception()
 
 # https://stackoverflow.com/a/66416364/318186
 def printException() -> None:
@@ -87,7 +97,7 @@ class Pseudo:
             result['error'] = err
             return result
         except Exception:
-            printException()
+            logException()
             return result
 
         # Resolving
@@ -98,7 +108,7 @@ class Pseudo:
             result['error'] = err
             return result
         except Exception:
-            printException()
+            logException()
             return result
 
         # Interpreting
@@ -109,7 +119,7 @@ class Pseudo:
         except builtin.RuntimeError as err:
             result['error'] = err
         except Exception:
-            printException()
+            logException()
         finally:
             return result
 

--- a/pseudocode/__init__.py
+++ b/pseudocode/__init__.py
@@ -18,6 +18,8 @@ from . import scanner, parser
 from .resolver import Resolver
 from .interpreter import Interpreter
 
+
+
 class Result(TypedDict):
     """The metadata dict passed to an Array declaration"""
     lines: List[str]
@@ -37,9 +39,16 @@ file   : program read from script file
 
 
 
-def logException() -> None:
+def logException(msg="Unexpected error has occurred") -> None:
     # https://docs.python.org/3.8/library/logging.html#logging.Logger.exception
-    logging.exception("Unexpected error has occurred")
+    logging.exception(msg)
+    print("Pseudo ERROR: " + msg)
+    print("""
+The details of this error have been logged in pseudo.log.
+
+Please help us detect and fix bugs in pseudo by reporting this error at
+https://github.com/nyjc-computing/pseudo-9608/issues/new/choose.
+""".strip())
 
 def report(lines: Iterable[str], err: builtin.PseudoError) -> None:
     errType = type(err).__name__ + ':'

--- a/pseudocode/interpreter.py
+++ b/pseudocode/interpreter.py
@@ -61,6 +61,7 @@ class Interpreter:
         self.outputHandler = handler  # type: ignore
 
     def interpret(self) -> None:
+        assert False
         executeStmts(
             self.frame,
             self.statements,

--- a/pseudocode/interpreter.py
+++ b/pseudocode/interpreter.py
@@ -61,7 +61,6 @@ class Interpreter:
         self.outputHandler = handler  # type: ignore
 
     def interpret(self) -> None:
-        assert False
         executeStmts(
             self.frame,
             self.statements,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pseudo-9608"
-version = "0.4.0"
+version = "0.4.1"
 description = "An interpreter for 9608 pseudocode"
 license = "MIT"
 authors = ["JS Ng <ngjunsiang@gmail.com>"]


### PR DESCRIPTION
We are almost ready to go! But once pseudo is released, someone is sure to run into a bug at some point, and they wouldn't know how to report it ... we'll need logs that they can submit. Which means implementing logging.

# Logging unexpected errors

We'll start simple, with an example coming from https://realpython.com/python-logging/:
https://github.com/nyjc-computing/pseudo-9608/blob/ec6d13e32807cff4ee2d68ffadcf678c9f7f6247/pseudocode/__init__.py#L6-L11

And we use `logging.exception()` to capture error information to the file: [ec6d13e32807cff4ee2d68ffadcf678c9f7f6247], [5ee99590e5a26350a0cf79e8df74ffe952170ea5]