### PR TITLE
28b Shrinkwrap: Single dispatch

### DIFF
--- a/pseudocode/interpreter.py
+++ b/pseudocode/interpreter.py
@@ -466,43 +466,67 @@ def execReturn(
 
 
 
+@singledispatch
 def execute(
     stmt: lang.Stmt,
     frame: lang.Frame,
     **kwargs,
 ) -> None:
     """Dispatcher for statement executors."""
-    if isinstance(stmt, lang.Output):
-        execOutput(stmt, frame, **kwargs)
-    elif isinstance(stmt, lang.Input):
-        execInput(stmt, frame, **kwargs)
-    elif isinstance(stmt, lang.Case):
-        execCase(stmt, frame, **kwargs)
-    elif isinstance(stmt, lang.If):
-        execIf(stmt, frame, **kwargs)
-    elif isinstance(stmt, lang.While):
-        execWhile(stmt, frame, **kwargs)
-    elif isinstance(stmt, lang.Repeat):
-        execRepeat(stmt, frame, **kwargs)
-    elif (
-        isinstance(stmt, lang.OpenFile)
-        or isinstance(stmt, lang.ReadFile)
-        or isinstance(stmt, lang.WriteFile)
-        or isinstance(stmt, lang.CloseFile)
-    ):
-        execFile(stmt, frame, **kwargs)
-    elif isinstance(stmt, lang.CallStmt):
-        execCall(stmt, frame, **kwargs)
-    elif isinstance(stmt, lang.AssignStmt):
-        execAssign(stmt, frame, **kwargs)
-    elif isinstance(stmt, lang.Return):
-        execReturn(stmt, frame, **kwargs)
-    elif (
-        isinstance(stmt, lang.DeclareStmt)
-        or isinstance(stmt, lang.TypeStmt)
-        or isinstance(stmt, lang.ProcedureStmt)
-        or isinstance(stmt, lang.FunctionStmt)
-    ):
-        pass
-    else:
-        raise ValueError(f"Invalid Stmt {stmt}")
+    raise TypeError(f"Invalid Stmt {stmt}")
+
+@execute.register
+def _(stmt: lang.Output, frame: lang.Frame, **kwargs) -> None:
+    execOutput(stmt, frame, **kwargs)
+
+@execute.register
+def _(stmt: lang.Input, frame: lang.Frame, **kwargs) -> None:
+    execInput(stmt, frame, **kwargs)
+
+@execute.register
+def _(stmt: lang.Case, frame: lang.Frame, **kwargs) -> None:
+    execCase(stmt, frame, **kwargs)
+
+@execute.register
+def _(stmt: lang.If, frame: lang.Frame, **kwargs) -> None:
+    execIf(stmt, frame, **kwargs)
+    
+@execute.register
+def _(stmt: lang.While, frame: lang.Frame, **kwargs) -> None:
+    execWhile(stmt, frame, **kwargs)
+    
+@execute.register
+def _(stmt: lang.Repeat, frame: lang.Frame, **kwargs) -> None:
+    execRepeat(stmt, frame, **kwargs)
+    
+@execute.register
+def _(stmt: lang.FileStmt, frame: lang.Frame, **kwargs) -> None:
+    execFile(stmt, frame, **kwargs)
+    
+@execute.register
+def _(stmt: lang.CallStmt, frame: lang.Frame, **kwargs) -> None:
+    execCall(stmt, frame, **kwargs)
+    
+@execute.register
+def _(stmt: lang.AssignStmt, frame: lang.Frame, **kwargs) -> None:
+    execAssign(stmt, frame, **kwargs)
+    
+@execute.register
+def _(stmt: lang.Return, frame: lang.Frame, **kwargs) -> None:
+    raise TypeError("Return Stmts should not be dispatched from execute()")
+    
+@execute.register
+def _(stmt: lang.DeclareStmt, frame: lang.Frame, **kwargs) -> None:
+    pass
+
+@execute.register
+def _(stmt: lang.TypeStmt, frame: lang.Frame, **kwargs) -> None:
+    pass
+
+@execute.register
+def _(stmt: lang.ProcedureStmt, frame: lang.Frame, **kwargs) -> None:
+    pass
+
+@execute.register
+def _(stmt: lang.FunctionStmt, frame: lang.Frame, **kwargs) -> None:
+    pass

--- a/pseudocode/interpreter.py
+++ b/pseudocode/interpreter.py
@@ -119,7 +119,7 @@ def evalGet(
     expr: lang.NameExpr,
     frame: lang.Frame,
     **kwargs,
-) -> lang.Value:
+):
     """Returns the name's associated value in a Frame."""
     assert not isinstance(expr, lang.UnresolvedName), "Unexpected UnresolvedName"
     if isinstance(expr, lang.GetName):
@@ -159,7 +159,7 @@ def evalCallable(
     args: lang.Args,
     frame: lang.Frame,
     **kwargs,
-) -> lang.Value: ...
+) -> Union[lang.PyLiteral, lang.Object, lang.Array]: ...
 def evalCallable(
     callable: Union[lang.Builtin, lang.Callable],
     args: lang.Args,
@@ -189,7 +189,7 @@ def evalCallable(
 def evalAssign(
     expr: lang.Assign,
     frame: lang.Frame,
-) -> lang.Value:
+) -> Union[lang.PyLiteral, lang.Object, lang.Array]:
     value = evaluate(expr.expr, frame)
     """Handles assignment of a value to an Object attribute, Array
     index, or Frame name.

--- a/pseudocode/interpreter.py
+++ b/pseudocode/interpreter.py
@@ -114,57 +114,6 @@ def evalBinary(
     rightval = evaluate(expr.right, frame)
     return expr.oper(leftval, rightval)
 
-# @singledispatch
-# def evalGet(
-#     expr: lang.NameExpr,
-#     frame: lang.Frame,
-#     **kwargs,
-# ):
-#     """Returns the name's associated value in a Frame."""
-#     raise TypeError("Unexpected {expr} in evalGet")
-
-# @evalGet.register
-# def _(
-#     expr: lang.GetName,
-#     frame: lang.Frame,
-#     **kwargs,
-# ) -> Union[lang.PyLiteral, lang.Object, lang.Array, lang.Builtin, lang.Callable]:
-#     value = expr.frame.getValue(str(expr.name))
-#     assert not isinstance(value, lang.File), "Unexpected File"
-#     return value
-
-# @evalGet.register
-# def _(
-#     expr: lang.GetIndex,
-#     frame: lang.Frame,
-#     **kwargs,
-# ) -> Union[lang.PyLiteral, lang.Object]:
-#     array = evalGet(expr.array, frame)
-#     assert isinstance(array, lang.Array), "Invalid Array"
-#     indexes = evalIndex(expr.index, frame)
-#     return array.getValue(indexes)
-
-# @evalGet.register
-# def _(
-#     expr: lang.GetAttr,
-#     frame: lang.Frame,
-#     **kwargs,
-# ) -> Union[lang.PyLiteral, lang.Object]:
-#     obj = evalGet(expr.object, frame)
-#     assert isinstance(obj, lang.Object), "Invalid Object"
-#     return obj.getValue(str(expr.name))
-
-# @evalGet.register
-# def _(
-#     expr: lang.Call,
-#     frame: lang.Frame,
-#     **kwargs,
-# ) -> Union[lang.PyLiteral, lang.Object, lang.Array]:
-#     callable = evalGet(expr.callable, frame)
-#     assert isinstance(callable, lang.Function), \
-#         f"Invalid Function {callable}"
-#     return evalCallable(callable, expr.args, frame)
-
 @singledispatch
 def evalCallable(callable, args, frame, **kwargs):
     """Returns the evaluated value of a Builtin/Callable."""

--- a/pseudocode/interpreter.py
+++ b/pseudocode/interpreter.py
@@ -114,29 +114,56 @@ def evalBinary(
     rightval = evaluate(expr.right, frame)
     return expr.oper(leftval, rightval)
 
+@singledispatch
 def evalGet(
     expr: lang.NameExpr,
     frame: lang.Frame,
     **kwargs,
 ):
     """Returns the name's associated value in a Frame."""
-    assert not isinstance(expr, lang.UnresolvedName), "Unexpected UnresolvedName"
-    if isinstance(expr, lang.GetName):
-        return expr.frame.getValue(str(expr.name))
-    if isinstance(expr, lang.GetIndex):
-        array = evalGet(expr.array, frame)
-        assert isinstance(array, lang.Array), "Invalid Array"
-        indexes = evalIndex(expr.index, frame)
-        return array.getValue(indexes)
-    if isinstance(expr, lang.GetAttr):
-        obj = evalGet(expr.object, frame)
-        assert isinstance(obj, lang.Object), "Invalid Object"
-        return obj.getValue(str(expr.name))
-    if isinstance(expr, lang.Call):
-        callable = evalGet(expr.callable, frame)
-        assert isinstance(callable, lang.Function), \
-            f"Invalid Function {callable}"
-        return evalCallable(callable, expr.args, frame)
+    raise TypeError("Unexpected {expr} in evalGet")
+
+@evalGet.register
+def _(
+    expr: lang.GetName,
+    frame: lang.Frame,
+    **kwargs,
+) -> Union[lang.PyLiteral, lang.Object, lang.Array, lang.Builtin, lang.Callable]:
+    value = expr.frame.getValue(str(expr.name))
+    assert not isinstance(value, lang.File), "Unexpected File"
+    return value
+
+@evalGet.register
+def _(
+    expr: lang.GetIndex,
+    frame: lang.Frame,
+    **kwargs,
+) -> Union[lang.PyLiteral, lang.Object]:
+    array = evalGet(expr.array, frame)
+    assert isinstance(array, lang.Array), "Invalid Array"
+    indexes = evalIndex(expr.index, frame)
+    return array.getValue(indexes)
+
+@evalGet.register
+def _(
+    expr: lang.GetAttr,
+    frame: lang.Frame,
+    **kwargs,
+) -> Union[lang.PyLiteral, lang.Object]:
+    obj = evalGet(expr.object, frame)
+    assert isinstance(obj, lang.Object), "Invalid Object"
+    return obj.getValue(str(expr.name))
+
+@evalGet.register
+def _(
+    expr: lang.Call,
+    frame: lang.Frame,
+    **kwargs,
+) -> Union[lang.PyLiteral, lang.Object, lang.Array]:
+    callable = evalGet(expr.callable, frame)
+    assert isinstance(callable, lang.Function), \
+        f"Invalid Function {callable}"
+    return evalCallable(callable, expr.args, frame)
 
 @singledispatch
 def evalCallable(callable, args, frame, **kwargs):

--- a/pseudocode/lang.py
+++ b/pseudocode/lang.py
@@ -301,7 +301,7 @@ class Object(PseudoValue):
 
 
 
-class Frame(Object):
+class Frame:
     """Frames differ from Objects in that they can be chained (with a
     reference to an outer Frame, names can be reassigned to a different
     TypedValue, and slots can be deleted after declaration.
@@ -323,8 +323,37 @@ class Frame(Object):
         typesys: "TypeSystem",
         outer: "Frame"=None,
     ) -> None:
-        super().__init__(typesys=typesys)
+        self.data: MutableMapping[NameKey, "TypedValue"] = {}
+        self.types = typesys
         self.outer = outer
+
+    def __repr__(self) -> str:
+        nameTypePairs = [
+            f"{name}: {self.getType(name)}"
+            for name in self.data
+        ]
+        return f"{{{', '.join(nameTypePairs)}}}"
+
+    def has(self, name: NameKey) -> bool:
+        return name in self.data
+
+    def declare(self, name: NameKey, type: str) -> None:
+        self.data[name] = self.types.cloneType(type)
+
+    def getType(self, name: NameKey) -> Type:
+        return self.data[name].type
+
+    def getValue(self, name: NameKey) -> Value:
+        returnval = self.data[name].value
+        if returnval is None:
+            raise ValueError(f"Accessed unassigned variable {name!r}")
+        return returnval
+
+    def get(self, name: NameKey) -> "TypedValue":
+        return self.data[name]
+
+    def setValue(self, name: NameKey, value: Value) -> None:
+        self.data[name].value = value
 
     def set(self, name: NameKey, typedValue: TypedValue) -> None:
         self.data[name] = typedValue

--- a/pseudocode/lang.py
+++ b/pseudocode/lang.py
@@ -44,7 +44,7 @@ Args = Collection["Expr"]  # Callable args
 ParamDecl = "Declare"  # ProcFunc params (in statement)
 # HACK: Should use TypeAlias but not yet supported in Python 3.8
 Param = Union["TypedValue"]  # Callable params (in the frame)
-Value = Union[PyLiteral, "PseudoValue"]  # in TypedValue
+Value = Union[PyLiteral, "Object", "Array", "Builtin", "Callable", "File"]  # in TypedValue
 Cases = MutableMapping[PyLiteral, List["Stmt"]]  # For Conditionals
 # NameExprs are GetExprs that use a NameKey
 NameKeyExpr = Union["UnresolvedName", "GetName"]
@@ -801,6 +801,7 @@ class TypeStmt(Stmt):
 
 class FileStmt(Stmt):
     """Base class for Stmts involving Files."""
+    filename: "Expr"
 
 @dataclass
 class OpenFile(FileStmt):

--- a/pseudocode/lang.py
+++ b/pseudocode/lang.py
@@ -283,10 +283,14 @@ class Object(PseudoValue):
     def getType(self, name: NameKey) -> Type:
         return self.data[name].type
 
-    def getValue(self, name: NameKey) -> Value:
+    def getValue(self, name: NameKey) -> Union[PyLiteral, "Object"]:
         returnval = self.data[name].value
         if returnval is None:
             raise ValueError(f"Accessed unassigned variable {name!r}")
+        assert not isinstance(returnval, Array), "Unexpected Array"
+        assert not isinstance(returnval, Builtin), "Unexpected Builtin"
+        assert not isinstance(returnval, Callable), "Unexpected Callable"
+        assert not isinstance(returnval, File), "Unexpected File"
         return returnval
 
     def get(self, name: NameKey) -> "TypedValue":
@@ -421,10 +425,14 @@ class Array(PseudoValue):
     def getType(self, index: IndexKey) -> Type:
         return self.data[index].type
 
-    def getValue(self, index: IndexKey) -> Value:
+    def getValue(self, index: IndexKey) -> Union[PyLiteral, Object]:
         returnval = self.data[index].value
         if returnval is None:
             raise ValueError(f"Accessed unassigned index {index!r}")
+        assert not isinstance(returnval, Array), "Unexpected Array"
+        assert not isinstance(returnval, Builtin), "Unexpected Builtin"
+        assert not isinstance(returnval, Callable), "Unexpected Callable"
+        assert not isinstance(returnval, File), "Unexpected File"
         return returnval
 
     def get(self, index: IndexKey) -> "TypedValue":

--- a/pseudocode/resolver.py
+++ b/pseudocode/resolver.py
@@ -203,12 +203,12 @@ def resolveProcCall(
     return callableType
 
 @singledispatch
-def resolve(expr, frame):
+def resolve(expr, frame, **kw):
     """Dispatcher for Expr resolvers."""
     raise TypeError(f"No resolver found for {expr}")
 
 @resolve.register
-def _(expr: lang.Literal, frame: lang.Frame) -> lang.Type:
+def _(expr: lang.Literal, frame: lang.Frame, **kw) -> lang.Type:
     return expr.type
 
 @resolve.register
@@ -228,7 +228,7 @@ def _(
     return expr.type
 
 @resolve.register
-def _(expr: lang.Unary, frame: lang.Frame) -> lang.Type:
+def _(expr: lang.Unary, frame: lang.Frame, **kw) -> lang.Type:
     resolveNamesInExpr(expr, frame)
     rType = resolve(expr.right, frame)
     if expr.oper is builtin.sub:
@@ -244,7 +244,7 @@ def _(expr: lang.Unary, frame: lang.Frame) -> lang.Type:
     raise ValueError(f"Unexpected oper {expr.oper}")
 
 @resolve.register
-def _(expr: lang.Binary, frame: lang.Frame) -> lang.Type:
+def _(expr: lang.Binary, frame: lang.Frame, **kw) -> lang.Type:
     resolveNamesInExpr(expr, frame)
     lType = resolve(expr.left, frame)
     rType = resolve(expr.right, frame)
@@ -294,7 +294,7 @@ def _(expr: lang.Binary, frame: lang.Frame) -> lang.Type:
     raise ValueError("No return for Binary")
 
 @resolve.register
-def _(expr: lang.Assign, frame: lang.Frame) -> lang.Type:
+def _(expr: lang.Assign, frame: lang.Frame, **kw) -> lang.Type:
     resolveNamesInExpr(expr, frame)
     assnType = resolve(expr.assignee, frame)
     exprType = resolve(expr.expr, frame)
@@ -302,7 +302,7 @@ def _(expr: lang.Assign, frame: lang.Frame) -> lang.Type:
     return assnType
 
 @resolve.register
-def _(expr: lang.Call, frame: lang.Frame) -> lang.Type:
+def _(expr: lang.Call, frame: lang.Frame, **kw) -> lang.Type:
     """Resolve a function call.
     Statement verification should be done in verifyFunction, not here.
     """
@@ -327,7 +327,7 @@ def _(expr: lang.Call, frame: lang.Frame) -> lang.Type:
     return callableType
 
 @resolve.register
-def _(expr: lang.GetIndex, frame: lang.Frame) -> lang.Type:
+def _(expr: lang.GetIndex, frame: lang.Frame, **kw) -> lang.Type:
     """Resolves a GetIndex Expr to return an array element's type"""
     def intsElseError(frame, *indexes):
         for indexExpr in indexes:
@@ -351,7 +351,7 @@ def _(expr: lang.GetIndex, frame: lang.Frame) -> lang.Type:
     return array.elementType
 
 @resolve.register
-def _(expr: lang.GetAttr, frame: lang.Frame) -> lang.Type:
+def _(expr: lang.GetAttr, frame: lang.Frame, **kw) -> lang.Type:
     """Resolves a GetAttr Expr to return an attribute's type"""
     resolveNamesInExpr(expr, frame)
     assert not isinstance(expr.object, lang.UnresolvedName), \
@@ -368,7 +368,7 @@ def _(expr: lang.GetAttr, frame: lang.Frame) -> lang.Type:
     return obj.getType(str(expr.name))
 
 @resolve.register
-def _(expr: lang.GetName, frame: lang.Frame) -> lang.Type:
+def _(expr: lang.GetName, frame: lang.Frame, **kw) -> lang.Type:
     """Returns the type of value that name is mapped to in frame."""
     return expr.frame.getType(str(expr.name))
 

--- a/pseudocode/resolver.py
+++ b/pseudocode/resolver.py
@@ -6,7 +6,7 @@ verify(frame: Frame, statements: list) -> None
 """
 
 from typing import Optional, Union, Literal
-from typing import Iterable, Iterator, Mapping, Collection
+from typing import Iterable, Iterator, Collection
 from typing import Tuple
 from functools import singledispatch
 from dataclasses import dataclass

--- a/pseudocode/resolver.py
+++ b/pseudocode/resolver.py
@@ -181,20 +181,6 @@ def declareByval(
         assert isinstance(frame, lang.Frame), "Frame expected"
         frame.setValue(name, array)
 
-def resolveDeclare(
-    declare: lang.Declare,
-    frame: Union[lang.Frame, lang.ObjectTemplate],
-    passby: Literal['BYVALUE', 'BYREF']='BYVALUE',
-) -> lang.Type:
-    """Declare variable in frame with dispatcher."""
-    if passby == 'BYVALUE':
-        declareByval(declare, frame)
-    else:
-        assert isinstance(frame, lang.Frame), \
-            "Declared BYREF in invalid Frame"
-        declareByref(declare, frame)
-    return declare.type
-
 def resolveUnary(
     expr: lang.Unary,
     frame: lang.Frame,
@@ -396,11 +382,18 @@ def _(expr: lang.Literal, frame: lang.Frame) -> lang.Type:
 @resolve.register
 def _(
     expr: lang.Declare,
-    frame: lang.Frame,
+    frame: Union[lang.Frame, lang.ObjectTemplate],
     *,
     passby: lang.Passby='BYVALUE',
 ) -> lang.Type:
-    return resolveDeclare(expr, frame, passby=passby)
+    """Declare variable in frame with dispatcher."""
+    if passby == 'BYVALUE':
+        declareByval(expr, frame)
+    else:
+        assert isinstance(frame, lang.Frame), \
+            "Declared BYREF in invalid Frame"
+        declareByref(expr, frame)
+    return expr.type
 
 @resolve.register
 def _(expr: lang.Unary, frame: lang.Frame) -> lang.Type:

--- a/pseudocode/resolver.py
+++ b/pseudocode/resolver.py
@@ -384,18 +384,6 @@ def resolveFuncCall(
     )
     return callableType
 
-resolver: Mapping = {
-    lang.Literal: resolveLiteral,
-    lang.Declare: resolveDeclare,
-    lang.Unary: resolveUnary,
-    lang.Binary: resolveBinary,
-    lang.Assign: resolveAssign,
-    lang.Call: resolveFuncCall,
-    lang.GetIndex: resolveIndex,
-    lang.GetAttr: resolveAttr,
-    lang.GetName: resolveGetName,
-}
-
 @singledispatch
 def resolve(expr, frame):
     """Dispatcher for Expr resolvers."""

--- a/pseudocode/resolver.py
+++ b/pseudocode/resolver.py
@@ -379,7 +379,7 @@ def resolveFuncCall(
     )
     return callableType
 
-resolver: Mapping[lang.Expr, function[[lang.Frame, lang.Expr], lang.Type]] = {
+resolver: Mapping = {
     lang.Literal: resolveLiteral,
     lang.Declare: resolveDeclare,
     lang.Unary: resolveUnary,

--- a/pseudocode/resolver.py
+++ b/pseudocode/resolver.py
@@ -309,7 +309,7 @@ def _(expr: lang.Call, frame: lang.Frame) -> lang.Type:
     resolveNamesInExpr(expr, frame)
     assert isinstance(expr.callable, lang.GetName), \
         "Unresolved Callable"
-    callableType = resolveGetName(expr.callable, frame)
+    callableType = resolve(expr.callable, frame)
     callFrame = expr.callable.frame
     callable = callFrame.getValue(str(expr.callable.name))
     if not (

--- a/pseudocode/resolver.py
+++ b/pseudocode/resolver.py
@@ -394,8 +394,13 @@ def _(expr: lang.Literal, frame: lang.Frame) -> lang.Type:
     return resolveLiteral(expr, frame)
 
 @resolve.register
-def _(expr: lang.Declare, frame: lang.Frame) -> lang.Type:
-    return resolveDeclare(expr, frame)
+def _(
+    expr: lang.Declare,
+    frame: lang.Frame,
+    *,
+    passby: lang.Passby='BYVALUE',
+) -> lang.Type:
+    return resolveDeclare(expr, frame, passby=passby)
 
 @resolve.register
 def _(expr: lang.Unary, frame: lang.Frame) -> lang.Type:

--- a/pseudocode/resolver.py
+++ b/pseudocode/resolver.py
@@ -396,14 +396,48 @@ resolver: Mapping = {
     lang.GetName: resolveGetName,
 }
 
+@singledispatch
 def resolve(expr, frame):
     """Dispatcher for Expr resolvers."""
-    exprtype = type(expr)
-    if exprtype not in resolver:
-        raise TypeError(f"Encountered {expr} in resolve()")
-    return resolver[exprtype](expr, frame)
+    raise TypeError(f"No resolver found for {expr}")
 
+@resolve.register
+def _(expr: lang.Literal, frame: lang.Frame) -> lang.Type:
+    return resolveLiteral(expr, frame)
 
+@resolve.register
+def _(expr: lang.Declare, frame: lang.Frame) -> lang.Type:
+    return resolveDeclare(expr, frame)
+
+@resolve.register
+def _(expr: lang.Unary, frame: lang.Frame) -> lang.Type:
+    return resolveUnary(expr, frame)
+
+@resolve.register
+def _(expr: lang.Binary, frame: lang.Frame) -> lang.Type:
+    return resolveBinary(expr, frame)
+
+@resolve.register
+def _(expr: lang.Assign, frame: lang.Frame) -> lang.Type:
+    return resolveAssign(expr, frame)
+
+@resolve.register
+def _(expr: lang.Call, frame: lang.Frame) -> lang.Type:
+    return resolveFuncCall(expr, frame)
+
+@resolve.register
+def _(expr: lang.GetIndex, frame: lang.Frame) -> lang.Type:
+    return resolveIndex(expr, frame)
+
+@resolve.register
+def _(expr: lang.GetAttr, frame: lang.Frame) -> lang.Type:
+    return resolveAttr(expr, frame)
+
+@resolve.register
+def _(expr: lang.GetName, frame: lang.Frame) -> lang.Type:
+    return resolveGetName(expr, frame)
+
+    
 
 # Verifiers
 

--- a/pseudocode/resolver.py
+++ b/pseudocode/resolver.py
@@ -512,17 +512,14 @@ def _(stmt: lang.TypeStmt, frame: lang.Frame) -> None:
 
 @verify.register
 def _(stmt: lang.CallStmt, frame: lang.Frame) -> None:
-    assert isinstance(stmt.expr, lang.Call), "Invalid Call"
     resolveProcCall(stmt.expr, frame)
 
 @verify.register
 def _(stmt: lang.AssignStmt, frame: lang.Frame) -> None:
-    assert isinstance(stmt.expr, lang.Assign), "Invalid Assign"
     resolve(stmt.expr, frame)
 
 @verify.register
 def _(stmt: lang.DeclareStmt, frame: lang.Frame) -> None:
-    assert isinstance(stmt.expr, lang.Declare), "Invalid Declare"
     resolve(stmt.expr, frame)
 
 @verify.register


### PR DESCRIPTION
Our resolver and interpreter use a technique known as **single dispatch**. This technique involves taking in an argument, and handling it differently depending on its type.

The current code for the resolver looks like this:
https://github.com/nyjc-computing/pseudo-9608/blob/922d15f963cbfeae36c0bfe6ed8c0d26a4038ef2/pseudocode/resolver.py#L382-L407