### PR TITLE
30c New features: Fixing CASE evaluations

### DIFF
--- a/main.pseudo
+++ b/main.pseudo
@@ -1,47 +1,13 @@
-// A comment
-DECLARE Length : INTEGER
-DECLARE Data : ARRAY[1:10] OF INTEGER
-DECLARE i : INTEGER
+DECLARE Test : STRING
 
-Length <- 10
+Test <- "Hi"
 
-PROCEDURE InsertSort(BYREF Data: ARRAY[1:10] OF INTEGER, Length: INTEGER)
-    DECLARE i : INTEGER
-    DECLARE p : INTEGER
-    DECLARE t : INTEGER
-    DECLARE Temp : INTEGER
-
-    IF Length > 1
-      THEN
-        FOR i <- 2 TO Length
-            p <- 1
-            WHILE p < i AND Data[i] > Data[p] DO
-                p <- p + 1
-            ENDWHILE
-            Temp <- Data[i]
-            WHILE i > p DO
-                Data[i] <- Data[i - 1]
-                i <- i - 1
-            ENDWHILE
-            Data[i] <- Temp
-        ENDFOR
-    ENDIF
-ENDPROCEDURE
-
-Data[1] <- 7
-Data[2] <- 9
-Data[3] <- 4
-Data[4] <- 1
-Data[5] <- 2
-Data[6] <- 3
-Data[7] <- 5
-Data[8] <- 10
-Data[9] <- 6
-Data[10] <- 8
-
-CALL InsertSort(Data, Length)
-
-FOR i <- 1 TO 10
-    OUTPUT "Index: " & INTTOSTRING(i) & ": " & INTTOSTRING(Data[i])
-ENDFOR
-// End of code
+CASE OF Test
+  "Hello": OUTPUT "Oh, hello there!"
+  "Hi": OUTPUT "Hihi!"
+  "Hi": OUTPUT "Hi again!"
+  "Yo": OUTPUT "Wassup?"
+  0: OUTPUT "Huh?"
+  0: OUTPUT "Sense of deja vu ..."
+  1: OUTPUT "No way..."
+ENDCASE

--- a/pseudocode/interpreter.py
+++ b/pseudocode/interpreter.py
@@ -252,11 +252,14 @@ def _(stmt: lang.Input, frame: lang.Frame, **kwargs) -> None:
 
 @execute.register
 def _(stmt: lang.Case, frame: lang.Frame, **kwargs) -> None:
-    cond = evaluate(stmt.cond, frame)
-    if cond in stmt.stmtMap:
-        executeStmts(stmt.stmtMap[cond], frame, **kwargs)
-    elif stmt.fallback:
-        executeStmts(stmt.fallback, frame, **kwargs)
+    condValue = evaluate(stmt.cond, frame)
+    for caseValue, stmts in stmt.stmtMap.items():
+        if evaluate(caseValue, frame) == condValue:
+            executeStmts(stmts, frame, **kwargs)
+            break
+    else:  # for loop completed normally, i.e. no matching cases
+        if stmt.fallback:
+            executeStmts(stmt.fallback, frame, **kwargs)
 
 @execute.register
 def _(stmt: lang.If, frame: lang.Frame, **kwargs) -> None:

--- a/pseudocode/lang.py
+++ b/pseudocode/lang.py
@@ -89,8 +89,8 @@ class Token:
 
     def __repr__(self) -> str:
         lineinfo = f"[Line {self.line} column {self.column}]"
-        valuestr = self.value or ''
-        return f"{lineinfo} {repr(self.word)} {valuestr}"
+        valuestr = self.value or self.word
+        return f"{lineinfo} {valuestr!r}"
 
 
 class Name:

--- a/pseudocode/lang.py
+++ b/pseudocode/lang.py
@@ -559,6 +559,12 @@ class Literal(Expr):
     value: PyLiteral
     token: Token
 
+    def __hash__(self):
+        return hash(self.value)
+
+    def __eq__(self, other: "Literal") -> bool:
+        return self.value == other.value
+
 
 @dataclass
 class Declare(Expr):

--- a/pseudocode/parser.py
+++ b/pseudocode/parser.py
@@ -465,7 +465,7 @@ def caseStmt(tokens: Tokens) -> lang.Case:
         tokens,
         ['OTHERWISE', 'ENDCASE'],
         lambda tokens: colonPair(tokens,
-                                 lambda tokens: literal(tokens).value,
+                                 lambda tokens: literal(tokens),
                                  lambda tokens: [statement1(tokens)])
     ))
     if matchWord(tokens, 'OTHERWISE'):

--- a/pseudocode/resolver.py
+++ b/pseudocode/resolver.py
@@ -389,8 +389,10 @@ def _(stmt: lang.Input, frame: lang.Frame) -> None:
 @verify.register
 def _(stmt: lang.Case, frame: lang.Frame) -> None:
     resolveNamesInTarget(stmt, frame)
-    resolve(stmt.cond, frame)
-    for statements in stmt.stmtMap.values():
+    condType = resolve(stmt.cond, frame)
+    for caseValue, statements in stmt.stmtMap.items():
+        caseType = resolve(caseValue, frame)
+        expectTypeElseError(caseType, condType, token=caseValue.token)
         verifyStmts(statements, frame)
     if stmt.fallback:
         verifyStmts(stmt.fallback, frame)

--- a/tests/test_case_repeat_value.py
+++ b/tests/test_case_repeat_value.py
@@ -3,7 +3,19 @@ import unittest
 import pseudocode
 
 TESTCODE = """
-IF TRUE
+DECLARE Test : STRING
+
+Test <- "Hi"
+
+CASE OF Test
+  "Hello": OUTPUT "Oh, hello there!"
+  "Hi": OUTPUT "Hihi!"
+  "Hi": OUTPUT "Hi again!"
+  "Yo": OUTPUT "Wassup?"
+  0: OUTPUT "Huh?"
+  0: OUTPUT "Sense of deja vu ..."
+  1: OUTPUT "No way..."
+ENDCASE
 """
 
 class ProcedureTestCase(unittest.TestCase):
@@ -23,4 +35,10 @@ class ProcedureTestCase(unittest.TestCase):
         self.assertIs(
             type(error),
             pseudocode.builtin.ParseError,
+        )
+        infoword = 'repeat'
+        self.assertIn(
+            infoword,
+            error.msg().lower(),
+            f"Error message does not contain {infoword!r}"
         )

--- a/tests/test_case_unmatched_type.py
+++ b/tests/test_case_unmatched_type.py
@@ -3,7 +3,17 @@ import unittest
 import pseudocode
 
 TESTCODE = """
-IF TRUE
+DECLARE Test : STRING
+
+Test <- "Hi"
+
+CASE OF Test
+  "Hello": OUTPUT "Oh, hello there!"
+  "Hi": OUTPUT "Hi again!"
+  "Yo": OUTPUT "Wassup?"
+  0: OUTPUT "Huh?"
+  1: OUTPUT "No way..."
+ENDCASE
 """
 
 class ProcedureTestCase(unittest.TestCase):
@@ -22,5 +32,11 @@ class ProcedureTestCase(unittest.TestCase):
         )
         self.assertIs(
             type(error),
-            pseudocode.builtin.ParseError,
+            pseudocode.builtin.LogicError,
+        )
+        infoword = 'expect'
+        self.assertIn(
+            infoword,
+            error.msg().lower(),
+            f"Error message does not contain {infoword!r}"
         )


### PR DESCRIPTION
We've implemented two new features so far, with few hiccups. Let's try something hairier: fixing a bug.

In [`main.pseudo`](https://github.com/nyjc-computing/pseudo-9608/blob/fc4307d332b941985f0d9ef9643d9ef6458ab6e6/main.pseudo):
```
DECLARE Test : STRING

Test <- "Hi"

CASE OF Test
  "Hello": OUTPUT "Oh, hello there!"
  "Hi": OUTPUT "Hihi!"
  "Hi": OUTPUT "Hi again!"
  "Yo": OUTPUT "Wassup?"
  0: OUTPUT "Huh?"
  0: OUTPUT "Sense of deja vu ..."
  1: OUTPUT "No way..."
ENDCASE
```

```
$ pseudo main.pseudo 
Hi again!
```

Doesn't seem like anything is wrong here ... the code runs, right? But this should rightfully throw an error or two:

1. The case values `"Hi"` and `0` are repeated, and our parser/resolver should have pointed that out since it is probably an inadvertent error on the user's part if it happens (unlike in this case).
2. The case condition, `Test`, is declared as STRING type, so all case values should also be STRING. `0` and `1` are invalid case values, and the resolver should have pointed this out.

Let's make that happen.