### PR TITLE
31a Defining behaviour: Cleaning up (again)

### DIFF
--- a/pseudocode/interpreter.py
+++ b/pseudocode/interpreter.py
@@ -263,11 +263,14 @@ def _(stmt: lang.Case, frame: lang.Frame, **kwargs) -> None:
 
 @execute.register
 def _(stmt: lang.If, frame: lang.Frame, **kwargs) -> None:
-    cond = evaluate(stmt.cond, frame)
-    if cond in stmt.stmtMap:
-        executeStmts(stmt.stmtMap[cond], frame, **kwargs)
-    elif stmt.fallback:
-        executeStmts(stmt.fallback, frame, **kwargs)
+    condValue = evaluate(stmt.cond, frame)
+    for caseValue, stmts in stmt.stmtMap.items():
+        if evaluate(caseValue, frame) == condValue:
+            executeStmts(stmts, frame, **kwargs)
+            break
+    else:  # for loop completed normally, i.e. no matching cases
+        if stmt.fallback:
+            executeStmts(stmt.fallback, frame, **kwargs)
     
 @execute.register
 def _(stmt: lang.While, frame: lang.Frame, **kwargs) -> None:

--- a/pseudocode/interpreter.py
+++ b/pseudocode/interpreter.py
@@ -265,7 +265,7 @@ def _(stmt: lang.Case, frame: lang.Frame, **kwargs) -> None:
 def _(stmt: lang.If, frame: lang.Frame, **kwargs) -> None:
     cond = evaluate(stmt.cond, frame)
     if cond in stmt.stmtMap:
-        executeStmts(stmt.stmtMap[True], frame, **kwargs)
+        executeStmts(stmt.stmtMap[cond], frame, **kwargs)
     elif stmt.fallback:
         executeStmts(stmt.fallback, frame, **kwargs)
     

--- a/pseudocode/lang.py
+++ b/pseudocode/lang.py
@@ -37,7 +37,7 @@ Type = str  # pseudocode type, whether built-in or declared
 IndexDigit = Union["Expr"]
 IndexExpr = Tuple[IndexDigit, ...]  # Array indexes
 IndexRange = Tuple[int, int]  # Array ranges (start, end)
-Passby = LiteralType['BYREF', 'BYVALUE']
+Passby = LiteralType["BYREF", "BYVALUE"]
 
 # Plurals
 Exprs = Iterable["Expr"]
@@ -80,7 +80,7 @@ class Token:
     and Stmts.
     It also encapsulates code information for error reporting.
     """
-    __slots__ = ('line', 'column', 'type', 'word', 'value')
+    __slots__ = ("line", "column", "type", "word", "value")
     line: int
     column: int
     type: Type
@@ -97,14 +97,14 @@ class Name:
     """Name represents a meaningful name, either a custom type or a
     variable name.
     """
-    __slots__ = ('name', '_token')
+    __slots__ = ("name", "_token")
 
     def __init__(self, name: NameKey, *, token: "Token") -> None:
         self.name = name
         self._token = token
 
     def __repr__(self) -> str:
-        return f'Name({self.name})'
+        return f"Name({self.name})"
 
     def __str__(self) -> NameKey:
         return self.name
@@ -119,7 +119,7 @@ class TypedValue:
     """All pseudocode values are encapsulated in a TypedValue.
     Each TypedValue has a type and a value.
     """
-    __slots__ = ('type', 'value')
+    __slots__ = ("type", "value")
     type: Type
     value: Optional[Value]
 
@@ -138,7 +138,7 @@ class TypeTemplate:
     clone()
         Returns a TypedValue of the same type
     """
-    __slots__ = ('type', 'value')
+    __slots__ = ("type", "value")
     type: Type
     value: Optional["ObjectTemplate"]
 
@@ -160,7 +160,7 @@ class ObjectTemplate:
     clone()
         Returns an empty Object of the same type
     """
-    __slots__ = ('types', 'data')
+    __slots__ = ("types", "data")
 
     def __init__(self, typesys: "TypeSystem") -> None:
         self.types = typesys
@@ -202,7 +202,7 @@ class TypeSystem:
     cloneType(type)
         return a copy of the template for the type
     """
-    __slots__ = ('data', )
+    __slots__ = ("data", )
 
     def __init__(self, *types: Type) -> None:
         self.data: MutableMapping[Type, TypeTemplate] = {}
@@ -255,7 +255,7 @@ class Object(PseudoValue):
     setValue(name, value)
         updates the value associated with the name
     """
-    __slots__ = ('types', 'data')
+    __slots__ = ("types", "data")
 
     def __init__(self, typesys: "TypeSystem") -> None:
         self.types = typesys
@@ -307,7 +307,7 @@ class Frame:
     lookup(name)
         returns the first frame containing the name
     """
-    __slots__ = ('types', 'data', 'outer')
+    __slots__ = ("types", "data", "outer")
 
     def __init__(self, typesys: "TypeSystem", outer: "Frame" = None) -> None:
         self.types = typesys
@@ -383,7 +383,7 @@ class Array(PseudoValue):
     setValue(name, value)
         updates the value associated with the name
     """
-    __slots__ = ('types', 'ranges', 'data')
+    __slots__ = ("types", "ranges", "data")
 
     def __init__(self, typesys: "TypeSystem", ranges: IndexRanges,
                  type: Type) -> None:
@@ -457,7 +457,7 @@ class Builtin(PseudoValue):
     - func
         the Python function to call when invoked
     """
-    __slots__ = ('frame', 'params', 'func')
+    __slots__ = ("frame", "params", "func")
     frame: "Frame"  # Builtins resolve with global frame
     params: Params
     func: function
@@ -477,7 +477,7 @@ class Callable(PseudoValue):
     - stmts
         A list of statements the callable executes when called
     """
-    __slots__ = ('frame', 'params', 'stmts')
+    __slots__ = ("frame", "params", "stmts")
     frame: "Frame"
     params: Params
     stmts: Stmts
@@ -505,7 +505,7 @@ class File(PseudoValue):
     - iohandler
         An object for accessing the file
     """
-    __slots__ = ('name', 'mode', 'iohandler')
+    __slots__ = ("name", "mode", "iohandler")
     name: NameKey
     mode: str
     iohandler: IO
@@ -534,7 +534,7 @@ class Literal(Expr):
     """A Literal represents any value coming directly from the source
     code.
     """
-    __slots__ = ('type', 'value', 'token')
+    __slots__ = ("type", "value", "token")
     type: Type
     value: PyLiteral
     token: Token
@@ -549,7 +549,7 @@ class Literal(Expr):
 @dataclass
 class Declare(Expr):
     """A Declare Expr associates a Name with its declared Type."""
-    __slots__ = ('name', 'type', 'metadata')
+    __slots__ = ("name", "type", "metadata")
     name: Name
     type: Type
     metadata: MutableMapping
@@ -562,10 +562,10 @@ class Declare(Expr):
 @dataclass
 class Assign(Expr):
     """An Assign Expr represents an assignment operation.
-    The Expr's evaluated value should be assigned to the Name/Index
+    The Expr"s evaluated value should be assigned to the Name/Index
     represented by the assignee.
     """
-    __slots__ = ('assignee', 'expr')
+    __slots__ = ("assignee", "expr")
     assignee: GetExpr
     expr: "Expr"
 
@@ -579,7 +579,7 @@ class Unary(Expr):
     """A Unary Expr represents the invocation of a unary callable with a
     single operand.
     """
-    __slots__ = ('oper', 'right', 'token')
+    __slots__ = ("oper", "right", "token")
     oper: function
     right: "Expr"
     token: Token
@@ -590,7 +590,7 @@ class Binary(Expr):
     """A Binary Expr represents the invocation of a binary callable
     with two operands.
     """
-    __slots__ = ('left', 'oper', 'right', 'token')
+    __slots__ = ("left", "oper", "right", "token")
     left: "Expr"
     oper: function
     right: "Expr"
@@ -607,7 +607,7 @@ class UnresolvedName(Expr):
     appropriate Get Expr should be used to contain the name and context
     instead.
     """
-    __slots__ = ('name', )
+    __slots__ = ("name", )
     name: Name
 
     @property
@@ -618,7 +618,7 @@ class UnresolvedName(Expr):
 @dataclass
 class GetName(Expr):
     """A GetName Expr represents a Name with a Frame context."""
-    __slots__ = ('frame', 'name')
+    __slots__ = ("frame", "name")
     frame: "Frame"
     name: Name
 
@@ -630,7 +630,7 @@ class GetName(Expr):
 @dataclass
 class GetIndex(Expr):
     """A GetName Expr represents a Index with an Array context."""
-    __slots__ = ('array', 'index')
+    __slots__ = ("array", "index")
     array: NameExpr
     index: IndexExpr
 
@@ -642,7 +642,7 @@ class GetIndex(Expr):
 @dataclass
 class GetAttr(Expr):
     """A GetName Expr represents a Name with an Object context."""
-    __slots__ = ('object', 'name')
+    __slots__ = ("object", "name")
     object: NameExpr
     name: Name
 
@@ -656,7 +656,7 @@ class Call(Expr):
     """A Call Expr represents the invocation of a Callable (Function or
     Procedure) with arguments.
     """
-    __slots__ = ('callable', 'args')
+    __slots__ = ("callable", "args")
     callable: NameKeyExpr
     args: Args
 
@@ -676,7 +676,7 @@ class Stmt:
 
 class ExprStmt(Stmt):
     """Base class for statements that contain only a single Expr."""
-    __slots__ = ('expr', )
+    __slots__ = ("expr", )
 
 
 @dataclass
@@ -707,7 +707,7 @@ class CallStmt(ExprStmt):
 class Output(Stmt):
     """Output encapsulates values to be displayed in a terminal/console.
     """
-    __slots__ = ('exprs', )
+    __slots__ = ("exprs", )
     exprs: "Exprs"
 
 
@@ -716,7 +716,7 @@ class Input(Stmt):
     """Output encapsulates a GetExpr to which user input should be
     assigned.
     """
-    __slots__ = ('keyExpr', )
+    __slots__ = ("keyExpr", )
     key: GetExpr
 
 
@@ -726,7 +726,7 @@ class Conditional(Stmt):
     A provided condition cond, when evaluated to a value, results in
     the associated statement(s) being executed.
     """
-    __slots__ = ('cond', 'stmtMap', 'fallback')
+    __slots__ = ("cond", "stmtMap", "fallback")
     cond: "Expr"
     stmtMap: CaseMap
     fallback: Optional[Stmts]
@@ -746,7 +746,7 @@ class Loop(Stmt):
     """Loop encapsulates statements to be executed repeatedly until its
     cond evaluates to a False value.
     """
-    __slots__ = ('init', 'cond', 'stmts')
+    __slots__ = ("init", "cond", "stmts")
     init: Optional["Expr"]
     cond: "Expr"
     stmts: Stmts
@@ -775,9 +775,9 @@ class Repeat(Loop):
 @dataclass
 class ProcFunc(Stmt):
     """ProcFunc encapsulates a declared Procedure or Function."""
-    __slots__ = ('name', 'passby', 'params', 'stmts', 'returnType')
+    __slots__ = ("name", "passby", "params", "stmts", "returnType")
     name: Name
-    passby: LiteralType['BYVALUE', 'BYREF']
+    passby: LiteralType["BYVALUE", "BYREF"]
     params: Iterable[Declare]
     stmts: Stmts
     returnType: Type
@@ -794,7 +794,7 @@ class FunctionStmt(ProcFunc):
 @dataclass
 class TypeStmt(Stmt):
     """TypeStmt encapsulates a declared custom Type."""
-    __slots__ = ('name', 'exprs')
+    __slots__ = ("name", "exprs")
     name: Name
     exprs: Iterable["Declare"]
 
@@ -806,26 +806,26 @@ class FileStmt(Stmt):
 
 @dataclass
 class OpenFile(FileStmt):
-    __slots__ = ('filename', 'mode')
+    __slots__ = ("filename", "mode")
     filename: "Expr"
     mode: str
 
 
 @dataclass
 class ReadFile(FileStmt):
-    __slots__ = ('filename', 'target')
+    __slots__ = ("filename", "target")
     filename: "Expr"
     target: GetExpr
 
 
 @dataclass
 class WriteFile(FileStmt):
-    __slots__ = ('filename', 'data')
+    __slots__ = ("filename", "data")
     filename: "Expr"
     data: "Expr"
 
 
 @dataclass
 class CloseFile(FileStmt):
-    __slots__ = ('filename', )
+    __slots__ = ("filename", )
     filename: "Expr"

--- a/pseudocode/lang.py
+++ b/pseudocode/lang.py
@@ -99,12 +99,7 @@ class Name:
     """
     __slots__ = ('name', '_token')
 
-    def __init__(
-        self,
-        name: NameKey,
-        *,
-        token: "Token",
-    ) -> None:
+    def __init__(self, name: NameKey, *, token: "Token") -> None:
         self.name = name
         self._token = token
 
@@ -148,9 +143,7 @@ class TypeTemplate:
     value: Optional["ObjectTemplate"]
 
     def clone(self) -> "TypedValue":
-        """
-        This returns an empty TypedValue of the same type
-        """
+        """This returns an empty TypedValue of the same type."""
         if isinstance(self.value, ObjectTemplate):
             return TypedValue(self.type, self.value.clone())
         return TypedValue(self.type, self.value)
@@ -167,10 +160,9 @@ class ObjectTemplate:
     clone()
         Returns an empty Object of the same type
     """
-    def __init__(
-        self,
-        typesys: "TypeSystem",
-    ) -> None:
+    __slots__ = ('types', 'data')
+
+    def __init__(self, typesys: "TypeSystem") -> None:
         self.types = typesys
         self.data: MutableMapping[NameKey, Type] = {}
 
@@ -210,10 +202,9 @@ class TypeSystem:
     cloneType(type)
         return a copy of the template for the type
     """
-    def __init__(
-        self,
-        *types: Type,
-    ) -> None:
+    __slots__ = ('data', )
+
+    def __init__(self, *types: Type) -> None:
         self.data: MutableMapping[Type, TypeTemplate] = {}
         for typeName in types:
             self.declare(typeName)
@@ -227,11 +218,7 @@ class TypeSystem:
     def declare(self, type: Type) -> None:
         self.data[type] = TypeTemplate(type, None)
 
-    def setTemplate(
-        self,
-        type: Type,
-        template: "ObjectTemplate",
-    ) -> None:
+    def setTemplate(self, type: Type, template: "ObjectTemplate") -> None:
         self.data[type].value = template
 
     def cloneType(self, type: Type) -> "TypedValue":
@@ -268,12 +255,11 @@ class Object(PseudoValue):
     setValue(name, value)
         updates the value associated with the name
     """
-    def __init__(
-        self,
-        typesys: "TypeSystem",
-    ) -> None:
-        self.data: NameMap = {}
+    __slots__ = ('types', 'data')
+
+    def __init__(self, typesys: "TypeSystem") -> None:
         self.types = typesys
+        self.data: NameMap = {}
 
     def __repr__(self) -> str:
         nameTypePairs = [f"{name}: {self.getType(name)}" for name in self.data]
@@ -321,13 +307,11 @@ class Frame:
     lookup(name)
         returns the first frame containing the name
     """
-    def __init__(
-        self,
-        typesys: "TypeSystem",
-        outer: "Frame" = None,
-    ) -> None:
-        self.data: NameMap = {}
+    __slots__ = ('types', 'data', 'outer')
+
+    def __init__(self, typesys: "TypeSystem", outer: "Frame" = None) -> None:
         self.types = typesys
+        self.data: NameMap = {}
         self.outer = outer
 
     def __repr__(self) -> str:
@@ -399,12 +383,10 @@ class Array(PseudoValue):
     setValue(name, value)
         updates the value associated with the name
     """
-    def __init__(
-        self,
-        typesys: "TypeSystem",
-        ranges: IndexRanges,
-        type: Type,
-    ) -> None:
+    __slots__ = ('types', 'ranges', 'data')
+
+    def __init__(self, typesys: "TypeSystem", ranges: IndexRanges,
+                 type: Type) -> None:
         self.types = typesys
         self.ranges = ranges
         self.data: IndexMap = {
@@ -495,7 +477,6 @@ class Callable(PseudoValue):
     - stmts
         A list of statements the callable executes when called
     """
-
     __slots__ = ('frame', 'params', 'stmts')
     frame: "Frame"
     params: Params
@@ -541,7 +522,6 @@ class Expr:
     token: Token
         Returns the token asociated with the expr
     """
-
     __slots__: Iterable[str] = tuple()
 
     @property
@@ -637,8 +617,7 @@ class UnresolvedName(Expr):
 
 @dataclass
 class GetName(Expr):
-    """A GetName Expr represents a Name with a Frame context.
-    """
+    """A GetName Expr represents a Name with a Frame context."""
     __slots__ = ('frame', 'name')
     frame: "Frame"
     name: Name
@@ -650,8 +629,7 @@ class GetName(Expr):
 
 @dataclass
 class GetIndex(Expr):
-    """A GetName Expr represents a Index with an Array context.
-    """
+    """A GetName Expr represents a Index with an Array context."""
     __slots__ = ('array', 'index')
     array: NameExpr
     index: IndexExpr
@@ -663,8 +641,7 @@ class GetIndex(Expr):
 
 @dataclass
 class GetAttr(Expr):
-    """A GetName Expr represents a Name with an Object context.
-    """
+    """A GetName Expr represents a Name with an Object context."""
     __slots__ = ('object', 'name')
     object: NameExpr
     name: Name
@@ -698,36 +675,31 @@ class Stmt:
 
 
 class ExprStmt(Stmt):
-    """Base class for statements that contain only a single Expr.
-    """
+    """Base class for statements that contain only a single Expr."""
     __slots__ = ('expr', )
 
 
 @dataclass
 class Return(ExprStmt):
-    """Return encapsulates the value to be returned from a Function.
-    """
+    """Return encapsulates the value to be returned from a Function."""
     expr: "Expr"
 
 
 @dataclass
 class AssignStmt(ExprStmt):
-    """AssignStmt encapsulates an Assign Expr.
-    """
+    """AssignStmt encapsulates an Assign Expr."""
     expr: "Assign"
 
 
 @dataclass
 class DeclareStmt(ExprStmt):
-    """DeclareStmt encapsulates a Declare Expr.
-    """
+    """DeclareStmt encapsulates a Declare Expr."""
     expr: "Declare"
 
 
 @dataclass
 class CallStmt(ExprStmt):
-    """CallStmt encapsulates a Call Expr.
-    """
+    """CallStmt encapsulates a Call Expr."""
     expr: "Call"
 
 
@@ -761,11 +733,13 @@ class Conditional(Stmt):
 
 
 @dataclass
-class Case(Conditional): ...
+class Case(Conditional):
+    ...
 
 
 @dataclass
-class If(Conditional): ...
+class If(Conditional):
+    ...
 
 
 class Loop(Stmt):

--- a/pseudocode/lang.py
+++ b/pseudocode/lang.py
@@ -542,7 +542,11 @@ class Literal(Expr):
     def __hash__(self):
         return hash(self.value)
 
-    def __eq__(self, other: "Literal") -> bool:
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Literal):
+            # Allow Python to try other.__eq__(self)
+            # See: https://stackoverflow.com/a/54816069
+            return NotImplemented
         return self.value == other.value
 
 

--- a/pseudocode/lang.py
+++ b/pseudocode/lang.py
@@ -552,7 +552,7 @@ class Declare(Expr):
     __slots__ = ("name", "type", "metadata")
     name: Name
     type: Type
-    metadata: MutableMapping
+    metadata: TypeMetadata
 
     @property
     def token(self):

--- a/pseudocode/lang.py
+++ b/pseudocode/lang.py
@@ -61,10 +61,8 @@ Value = Union[PyLiteral, "Object", "Array", "Builtin", "Callable",
 
 # NameExprs are GetExprs that use a NameKey
 NameKeyExpr = Union["UnresolvedName", "GetName"]
-# GetExprs hold Exprs that evaluate to a KeyMap and a Key
-GetExpr = Union["UnresolvedName", "GetName", "GetAttr", "GetIndex"]
 # NameExprs start with a name
-NameExpr = Union[GetExpr, "Call"]
+NameExpr = Union["GetExpr", "Call"]
 
 
 class TypeMetadata(TypedDict, total=False):
@@ -570,7 +568,7 @@ class Assign(Expr):
     represented by the assignee.
     """
     __slots__ = ("assignee", "expr")
-    assignee: GetExpr
+    assignee: "GetExpr"
     expr: "Expr"
 
     @property
@@ -620,7 +618,18 @@ class UnresolvedName(Expr):
 
 
 @dataclass
-class GetName(Expr):
+class GetExpr(Expr):
+    """Base class for Exprs involving Names.
+
+    Such expressions involve a context, and a key for extracting data
+    from the context.
+    
+    E.g. Variable evaluation, array indexing, object attribute access
+    """
+
+
+@dataclass
+class GetName(GetExpr):
     """A GetName Expr represents a Name with a Frame context."""
     __slots__ = ("frame", "name")
     frame: "Frame"
@@ -632,7 +641,7 @@ class GetName(Expr):
 
 
 @dataclass
-class GetIndex(Expr):
+class GetIndex(GetExpr):
     """A GetName Expr represents a Index with an Array context."""
     __slots__ = ("array", "index")
     array: NameExpr
@@ -644,7 +653,7 @@ class GetIndex(Expr):
 
 
 @dataclass
-class GetAttr(Expr):
+class GetAttr(GetExpr):
     """A GetName Expr represents a Name with an Object context."""
     __slots__ = ("object", "name")
     object: NameExpr
@@ -721,7 +730,7 @@ class Input(Stmt):
     assigned.
     """
     __slots__ = ("keyExpr", )
-    key: GetExpr
+    key: "GetExpr"
 
 
 @dataclass
@@ -819,7 +828,7 @@ class OpenFile(FileStmt):
 class ReadFile(FileStmt):
     __slots__ = ("filename", "target")
     filename: "Expr"
-    target: GetExpr
+    target: "GetExpr"
 
 
 @dataclass

--- a/pseudocode/parser.py
+++ b/pseudocode/parser.py
@@ -528,7 +528,8 @@ def ifStmt(tokens: Tokens) -> lang.If:
     matchWordElseError(tokens, 'THEN')
     matchWordElseError(tokens, '\n', msg="after THEN")
     stmts: lang.CaseMap = {
-        True: parseUntilExpectWord(tokens, ['ELSE', 'ENDIF'], statement1)
+        lang.Literal('BOOLEAN', True, cond.token):
+        parseUntilExpectWord(tokens, ['ELSE', 'ENDIF'], statement1)
     }
     if matchWord(tokens, 'ELSE'):
         matchWordElseError(tokens, '\n', msg="after ELSE")

--- a/pseudocode/parser.py
+++ b/pseudocode/parser.py
@@ -4,7 +4,7 @@ parse(tokens: str) -> statements: list
     Parses tokens and returns a list of statements.
 """
 
-from typing import Any, Optional, Union, Iterable, Mapping, Tuple, List
+from typing import Optional, Iterable, Mapping, Tuple, List
 from typing import TypeVar, Callable as function
 
 from . import builtin, lang

--- a/pseudocode/parser.py
+++ b/pseudocode/parser.py
@@ -15,13 +15,13 @@ R = TypeVar('R')  # Return type
 R1 = TypeVar('R1')  # Additional return type
 R2 = TypeVar('R2')  # Additional return type
 
-
-
 # Helper functions
+
 
 def atEnd(tokens: Tokens) -> bool:
     """Returns True if at last token."""
     return check(tokens).type == 'EOF'
+
 
 def atEndThenError(tokens: Tokens) -> None:
     """Raises ParseError if at last token.
@@ -31,14 +31,17 @@ def atEndThenError(tokens: Tokens) -> None:
     if atEnd(tokens):
         raise builtin.ParseError("Unexpected EOF", check(tokens))
 
+
 def check(tokens: Tokens) -> lang.Token:
     """Returns token at cursor."""
     return tokens[0]
+
 
 def consume(tokens: Tokens) -> lang.Token:
     """Returns token at cursor, advances cursor."""
     token = tokens.pop(0)
     return token
+
 
 def expectWord(tokens: Tokens, *words: str) -> Optional[lang.Token]:
     """Returns token at cursor if its word matches given sequence of
@@ -48,6 +51,7 @@ def expectWord(tokens: Tokens, *words: str) -> Optional[lang.Token]:
         return check(tokens)
     atEndThenError(tokens)
     return None
+
 
 def expectType(
     tokens: Tokens,
@@ -61,6 +65,7 @@ def expectType(
     atEndThenError(tokens)
     return None
 
+
 def matchWord(tokens: Tokens, *words: str) -> Optional[lang.Token]:
     """Returns token at cursor if its word matches given sequence of
     words, otherwise returns None.
@@ -72,6 +77,7 @@ def matchWord(tokens: Tokens, *words: str) -> Optional[lang.Token]:
         return consume(tokens)
     atEndThenError(tokens)
     return None
+
 
 def matchType(
     tokens: Tokens,
@@ -88,10 +94,11 @@ def matchType(
     atEndThenError(tokens)
     return None
 
+
 def matchWordElseError(
     tokens: Tokens,
     *words: str,
-    msg: str='',
+    msg: str = '',
 ) -> lang.Token:
     """Returns token at cursor if its word matches given sequence of
     words, otherwise returns None.
@@ -105,10 +112,11 @@ def matchWordElseError(
     msg = f"Expected {words}" + (f' {msg}' if msg else '')
     raise builtin.ParseError(msg, check(tokens))
 
+
 def matchTypeElseError(
     tokens: Tokens,
     *types: lang.Type,
-        msg: str='',
+    msg: str = '',
 ) -> lang.Token:
     """Returns token at cursor if its type matches given sequence of
     types, otherwise returns None.
@@ -121,6 +129,7 @@ def matchTypeElseError(
         return token
     msg = f"Expected {types}" + (f' {msg}' if msg else '')
     raise builtin.ParseError(msg, check(tokens))
+
 
 def parseUntilExpectWord(
     tokens: Tokens,
@@ -136,6 +145,7 @@ def parseUntilExpectWord(
         parsedStmts += [parse(tokens)]
     return parsedStmts
 
+
 def parseUntilMatchWord(
     tokens: Tokens,
     matchWords: Iterable[str],
@@ -150,6 +160,7 @@ def parseUntilMatchWord(
     while not matchWord(tokens, *matchWords):
         parsedStmts += [parse(tokens)]
     return parsedStmts
+
 
 def buildExprWhileWord(
     tokens: Tokens,
@@ -171,6 +182,7 @@ def buildExprWhileWord(
         rootExpr = parser(tokens, rootExpr)
     return rootExpr
 
+
 def collectExprsWhileWord(
     tokens: Tokens,
     goWords: Iterable[str],
@@ -184,6 +196,7 @@ def collectExprsWhileWord(
     while matchWord(tokens, *goWords):
         parsedExprs += [parse(tokens)]
     return parsedExprs
+
 
 def colonPair(
     tokens: Tokens,
@@ -199,11 +212,10 @@ def colonPair(
     right = parseRight(tokens)
     return left, right
 
-def makeBinary(
-    expr: lang.Expr, operToken: lang.Token, right: lang.Expr
-) -> lang.Binary:
-    return lang.Binary(expr, operToken.value, right, token=operToken)
 
+def makeBinary(expr: lang.Expr, operToken: lang.Token,
+               right: lang.Expr) -> lang.Binary:
+    return lang.Binary(expr, operToken.value, right, token=operToken)
 
 
 # Precedence parsers
@@ -218,6 +230,7 @@ def makeBinary(
 # 5. <> | =
 # 6. AND | OR
 
+
 def identifier(tokens: Tokens) -> lang.UnresolvedName:
     if expectType(tokens, 'name'):
         token = consume(tokens)
@@ -225,14 +238,17 @@ def identifier(tokens: Tokens) -> lang.UnresolvedName:
         return lang.UnresolvedName(name)
     raise builtin.ParseError(f"Expected variable name", consume(tokens))
 
+
 def literal(tokens: Tokens) -> lang.Literal:
     token = matchTypeElseError(tokens, *builtin.LITERAL, msg="index")
     return lang.Literal(token.type, token.value, token=token)
+
 
 def unary(tokens: Tokens) -> lang.Unary:
     oper = consume(tokens)
     right: lang.Expr = value(tokens)
     return lang.Unary(oper.value, right, token=oper)
+
 
 def grouping(tokens: Tokens) -> lang.Expr:
     matchWord(tokens, '(')
@@ -240,10 +256,8 @@ def grouping(tokens: Tokens) -> lang.Expr:
     matchWordElseError(tokens, ')', msg="after '('")
     return expr
 
-def callExpr(
-    tokens: Tokens,
-    callableExpr: lang.NameKeyExpr,
-) -> lang.Call:
+
+def callExpr(tokens: Tokens, callableExpr: lang.NameKeyExpr) -> lang.Call:
     args: Tuple[lang.Expr, ...] = tuple()
     while not expectWord(tokens, ')'):
         if len(args) > 0:
@@ -252,43 +266,44 @@ def callExpr(
     matchWordElseError(tokens, ')', msg="after '('")
     return lang.Call(callableExpr, args)
 
+
 def attrExpr(tokens: Tokens, objExpr: lang.Expr) -> lang.GetAttr:
-    assert (
-        isinstance(objExpr, lang.UnresolvedName)
-        or isinstance(objExpr, lang.Call)
-        or isinstance(objExpr, lang.GetAttr)
-        or isinstance(objExpr, lang.GetIndex)
-    ), f"{objExpr!r}: Invalid NameExpr"
+    assert (isinstance(objExpr, lang.UnresolvedName)
+            or isinstance(objExpr, lang.Call)
+            or isinstance(objExpr, lang.GetAttr) or isinstance(
+                objExpr, lang.GetIndex)), f"{objExpr!r}: Invalid NameExpr"
     name = identifier(tokens).name  # Extract Name from UnresolvedName
     return lang.GetAttr(objExpr, name)
 
+
 def indexExpr(tokens: Tokens, arrayExpr: lang.Expr) -> lang.GetIndex:
-    assert (
-        isinstance(arrayExpr, lang.UnresolvedName)
-        or isinstance(arrayExpr, lang.Call)
-        or isinstance(arrayExpr, lang.GetAttr)
-        or isinstance(arrayExpr, lang.GetIndex)
-    ), f"{arrayExpr!r}: Invalid NameExpr"
+    assert (isinstance(arrayExpr, lang.UnresolvedName)
+            or isinstance(arrayExpr, lang.Call)
+            or isinstance(arrayExpr, lang.GetAttr) or isinstance(
+                arrayExpr, lang.GetIndex)), f"{arrayExpr!r}: Invalid NameExpr"
     index = tuple(collectExprsWhileWord(tokens, [','], expression))
     matchWordElseError(tokens, ']')
     return lang.GetIndex(arrayExpr, index)
+
 
 def name(tokens: Tokens) -> lang.NameExpr:
     expr: lang.UnresolvedName = identifier(tokens)
     nameExpr = buildExprWhileWord(
         tokens,
-        parserMap={'[': indexExpr, '.': attrExpr},
+        parserMap={
+            '[': indexExpr,
+            '.': attrExpr
+        },
         # Check for function call
         rootExpr=callExpr(tokens, expr) if matchWord(tokens, '(') else expr,
         advance=True,
     )
-    assert (
-        isinstance(nameExpr, lang.UnresolvedName)
-        or isinstance(nameExpr, lang.Call)
-        or isinstance(nameExpr, lang.GetAttr)
-        or isinstance(nameExpr, lang.GetIndex)
-    ), f"{nameExpr!r}: Invalid NameExpr"
+    assert (isinstance(nameExpr, lang.UnresolvedName)
+            or isinstance(nameExpr, lang.Call)
+            or isinstance(nameExpr, lang.GetAttr) or isinstance(
+                nameExpr, lang.GetIndex)), f"{nameExpr!r}: Invalid NameExpr"
     return nameExpr
+
 
 def value(tokens: Tokens):
     """Dispatcher for highest-precedence parsing functions.
@@ -308,31 +323,44 @@ def value(tokens: Tokens):
     else:
         raise builtin.ParseError("Unexpected token", check(tokens))
 
+
 def muldiv(tokens: Tokens) -> lang.Expr:
     # *, /
     expr: lang.Expr = value(tokens)
-    parser = lambda tokens, expr: makeBinary(expr, consume(tokens), value(tokens))
+    parser = lambda tokens, expr: makeBinary(expr, consume(tokens),
+                                             value(tokens))
     expr = buildExprWhileWord(
         tokens,
-        parserMap={'*': parser, '/': parser},
+        parserMap={
+            '*': parser,
+            '/': parser
+        },
         rootExpr=expr,
     )
     return expr
 
+
 def addsub(tokens: Tokens) -> lang.Expr:
     expr = muldiv(tokens)
-    parser = lambda tokens, expr: makeBinary(expr, consume(tokens), muldiv(tokens))
+    parser = lambda tokens, expr: makeBinary(expr, consume(tokens),
+                                             muldiv(tokens))
     expr = buildExprWhileWord(
         tokens,
-        parserMap={'+': parser, '-': parser, '&': parser},
+        parserMap={
+            '+': parser,
+            '-': parser,
+            '&': parser
+        },
         rootExpr=expr,
     )
     return expr
+
 
 def comparison(tokens: Tokens) -> lang.Expr:
     # <, <=, >, >=
     expr = addsub(tokens)
-    parser = lambda tokens, expr: makeBinary(expr, consume(tokens), addsub(tokens))
+    parser = lambda tokens, expr: makeBinary(expr, consume(tokens),
+                                             addsub(tokens))
     expr = buildExprWhileWord(
         tokens,
         parserMap={
@@ -345,66 +373,79 @@ def comparison(tokens: Tokens) -> lang.Expr:
     )
     return expr
 
+
 def equality(tokens: Tokens) -> lang.Expr:
     # <>, =
     expr = comparison(tokens)
-    parser = lambda tokens, expr: makeBinary(
-        expr, consume(tokens), comparison(tokens)
-    )
+    parser = lambda tokens, expr: makeBinary(expr, consume(tokens),
+                                             comparison(tokens))
     expr = buildExprWhileWord(
         tokens,
-        parserMap={'<>': parser, '=': parser},
+        parserMap={
+            '<>': parser,
+            '=': parser
+        },
         rootExpr=expr,
     )
     return expr
 
+
 def logical(tokens: Tokens) -> lang.Expr:
     # AND, OR
     expr = equality(tokens)
-    parser = lambda tokens, expr: makeBinary(
-        expr, consume(tokens), equality(tokens)
-    )
+    parser = lambda tokens, expr: makeBinary(expr, consume(tokens),
+                                             equality(tokens))
     expr = buildExprWhileWord(
         tokens,
-        parserMap={'AND': parser, 'OR': parser},
+        parserMap={
+            'AND': parser,
+            'OR': parser
+        },
         rootExpr=expr,
     )
     return expr
+
 
 def expression(tokens: Tokens) -> lang.Expr:
     expr = logical(tokens)
     return expr
 
+
 def assignment(tokens: Tokens) -> lang.Assign:
     unresolvedName: lang.UnresolvedName = identifier(tokens)
     assignee = buildExprWhileWord(
         tokens,
-        parserMap={'[': indexExpr, '.': attrExpr},
+        parserMap={
+            '[': indexExpr,
+            '.': attrExpr
+        },
         rootExpr=unresolvedName,
         advance=True,
     )
-    assert (
-        isinstance(assignee, lang.UnresolvedName)
-        or isinstance(assignee, lang.GetAttr)
-        or isinstance(assignee, lang.GetIndex)
-    ), f"{assignee!r}: Invalid assignee"
+    assert (isinstance(assignee, lang.UnresolvedName)
+            or isinstance(assignee, lang.GetAttr) or isinstance(
+                assignee, lang.GetIndex)), f"{assignee!r}: Invalid assignee"
     matchWordElseError(tokens, '<-', msg="after name")
     expr = expression(tokens)
     return lang.Assign(assignee, expr)
 
+
 # Statement parsers
 # Statements are detected based on the first keyword of the line.
 # Statements beginning with a name are assumed to be AssignStmts.
+
 
 def outputStmt(tokens: Tokens) -> lang.Output:
     exprs = collectExprsWhileWord(tokens, [','], expression)
     matchWordElseError(tokens, '\n', msg="after statement")
     return lang.Output(exprs)
 
+
 def inputStmt(tokens: Tokens) -> lang.Input:
     name = identifier(tokens)
     matchWordElseError(tokens, '\n', msg="after statement")
     return lang.Input(name)
+
 
 def colonRange(tokens: Tokens) -> lang.IndexRange:
     """Parse and return a start:end range as a tuple"""
@@ -413,12 +454,11 @@ def colonRange(tokens: Tokens) -> lang.IndexRange:
     range_end = matchTypeElseError(tokens, 'INTEGER')
     return (range_start.value, range_end.value)
 
+
 def declare(tokens: Tokens) -> lang.Declare:
     def expectTypeToken(tokens: Tokens):
-        if not (
-            expectWord(tokens, *builtin.TYPES)
-            or expectType(tokens, 'name')
-        ):
+        if not (expectWord(tokens, *builtin.TYPES)
+                or expectType(tokens, 'name')):
             raise builtin.ParseError("Invalid type", check(tokens))
 
     name, typetoken = colonPair(tokens, identifier, consume)
@@ -427,19 +467,20 @@ def declare(tokens: Tokens) -> lang.Declare:
     if typetoken.word == 'ARRAY':
         matchWordElseError(tokens, '[')
         indexRanges: List[lang.IndexRange] = collectExprsWhileWord(
-            tokens, [','], colonRange
-        )
+            tokens, [','], colonRange)
         metadata['size'] = indexRanges
         matchWordElseError(tokens, ']')
         matchWordElseError(tokens, 'OF')
         expectTypeToken(tokens)
         metadata['type'] = consume(tokens).word
     return lang.Declare(name.name, typetoken.word, metadata)
-    
+
+
 def declareStmt(tokens: Tokens) -> lang.DeclareStmt:
     expr = declare(tokens)
     matchWordElseError(tokens, '\n', msg="after statement")
     return lang.DeclareStmt(expr)
+
 
 def typeStmt(tokens: Tokens) -> lang.TypeStmt:
     name = identifier(tokens).name  # Extract Name from UnresolvedName
@@ -452,10 +493,12 @@ def typeStmt(tokens: Tokens) -> lang.TypeStmt:
     matchWordElseError(tokens, '\n')
     return lang.TypeStmt(name, exprs)
 
+
 def assignStmt(tokens: Tokens) -> lang.AssignStmt:
     expr = assignment(tokens)
     matchWordElseError(tokens, '\n', msg="after statement")
     return lang.AssignStmt(expr)
+
 
 def caseStmt(tokens: Tokens) -> lang.Case:
     matchWordElseError(tokens, 'OF', msg="after CASE")
@@ -463,12 +506,9 @@ def caseStmt(tokens: Tokens) -> lang.Case:
     matchWordElseError(tokens, '\n', msg="after CASE OF")
     caseStmts: lang.CaseMap = dict()
     caseMap = parseUntilExpectWord(
-        tokens,
-        ['OTHERWISE', 'ENDCASE'],
-        lambda tokens: colonPair(tokens,
-                                 lambda tokens: literal(tokens),
-                                 lambda tokens: [statement1(tokens)])
-    )
+        tokens, ['OTHERWISE', 'ENDCASE'],
+        lambda tokens: colonPair(tokens, lambda tokens: literal(tokens), lambda
+                                 tokens: [statement1(tokens)]))
     for caseValue, stmts in caseMap:
         if caseValue in caseStmts:
             raise builtin.ParseError(f"Repeated CASE value", caseValue.token)
@@ -480,6 +520,7 @@ def caseStmt(tokens: Tokens) -> lang.Case:
     matchWordElseError(tokens, 'ENDCASE', msg="at end of CASE")
     matchWordElseError(tokens, '\n', msg="after ENDCASE")
     return lang.Case(cond, caseStmts, fallback)
+
 
 def ifStmt(tokens: Tokens) -> lang.If:
     cond = expression(tokens)
@@ -498,6 +539,7 @@ def ifStmt(tokens: Tokens) -> lang.If:
     matchWordElseError(tokens, '\n', msg="after statement")
     return lang.If(cond, stmts, fallback)
 
+
 def whileStmt(tokens: Tokens) -> lang.While:
     cond = expression(tokens)
     matchWordElseError(tokens, 'DO', msg="after WHILE condition")
@@ -506,12 +548,14 @@ def whileStmt(tokens: Tokens) -> lang.While:
     matchWordElseError(tokens, '\n', msg="after ENDWHILE")
     return lang.While(None, cond, stmts)
 
+
 def repeatStmt(tokens: Tokens) -> lang.Repeat:
     matchWordElseError(tokens, '\n', msg="after REPEAT")
     stmts = parseUntilMatchWord(tokens, ['UNTIL'], statement4)
     cond = expression(tokens)
     matchWordElseError(tokens, '\n', msg="at end of UNTIL")
     return lang.Repeat(None, cond, stmts)
+
 
 def forStmt(tokens: Tokens) -> lang.While:
     init = assignment(tokens)
@@ -539,6 +583,7 @@ def forStmt(tokens: Tokens) -> lang.While:
     # incrStmt = lang.AssignStmt(incr)
     return lang.While(init, cond, stmts + [lang.AssignStmt(incr)])
 
+
 def procedureStmt(tokens: Tokens) -> lang.ProcedureStmt:
     name = identifier(tokens).name  # Extract Name from UnresolvedName
     params: List[lang.Declare] = []
@@ -554,10 +599,12 @@ def procedureStmt(tokens: Tokens) -> lang.ProcedureStmt:
     matchWordElseError(tokens, '\n', msg="after ENDPROCEDURE")
     return lang.ProcedureStmt(name, passby, params, stmts, 'NULL')
 
+
 def callStmt(tokens: Tokens) -> lang.CallStmt:
     callable: lang.Call = value(tokens)
     matchWordElseError(tokens, '\n')
     return lang.CallStmt(callable)
+
 
 def functionStmt(tokens: Tokens) -> lang.FunctionStmt:
     name = identifier(tokens).name  # Extract Name from UnresolvedName
@@ -579,19 +626,24 @@ def functionStmt(tokens: Tokens) -> lang.FunctionStmt:
         typetoken.word,
     )
 
+
 def returnStmt(tokens: Tokens) -> lang.Return:
     expr = expression(tokens)
     matchWordElseError(tokens, '\n', msg="at end of RETURN")
     return lang.Return(expr)
 
+
 def openfileStmt(tokens: Tokens) -> lang.OpenFile:
     filename: lang.Expr = value(tokens)
     matchWordElseError(tokens, 'FOR', msg="after file identifier")
-    mode = matchWordElseError(
-        tokens, 'READ', 'WRITE', 'APPEND', msg="Invalid file mode"
-    )
+    mode = matchWordElseError(tokens,
+                              'READ',
+                              'WRITE',
+                              'APPEND',
+                              msg="Invalid file mode")
     matchWordElseError(tokens, '\n')
     return lang.OpenFile(filename, mode.word)
+
 
 def readfileStmt(tokens: Tokens) -> lang.ReadFile:
     filename: lang.Expr = value(tokens)
@@ -600,6 +652,7 @@ def readfileStmt(tokens: Tokens) -> lang.ReadFile:
     matchWordElseError(tokens, '\n')
     return lang.ReadFile(filename, varname)
 
+
 def writefileStmt(tokens: Tokens) -> lang.WriteFile:
     filename: lang.Expr = value(tokens)
     matchWordElseError(tokens, ',', msg="after file identifier")
@@ -607,10 +660,12 @@ def writefileStmt(tokens: Tokens) -> lang.WriteFile:
     matchWordElseError(tokens, '\n')
     return lang.WriteFile(filename, data)
 
+
 def closefileStmt(tokens: Tokens) -> lang.CloseFile:
     filename: lang.Expr = value(tokens)
     matchWordElseError(tokens, '\n')
     return lang.CloseFile(filename)
+
 
 # Statement hierarchy
 # Statements are parsed in this order (most to least restrictive):
@@ -628,10 +683,12 @@ def closefileStmt(tokens: Tokens) -> lang.CloseFile:
 # 6. OUTPUT | INPUT | CALL | Assign | OPEN/READ/WRITE/CLOSEFILE
 #    may be used anywhere in a program
 
+
 def statement1(tokens: Tokens) -> lang.Stmt:
     if matchWord(tokens, 'RETURN'):
         return returnStmt(tokens)
     return statement3(tokens)
+
 
 def statement2(tokens: Tokens) -> lang.Stmt:
     if matchWord(tokens, 'FUNCTION'):
@@ -640,12 +697,14 @@ def statement2(tokens: Tokens) -> lang.Stmt:
         return procedureStmt(tokens)
     return statement3(tokens)
 
+
 def statement3(tokens: Tokens) -> lang.Stmt:
     if matchWord(tokens, 'DECLARE'):
         return declareStmt(tokens)
     if matchWord(tokens, 'TYPE'):
         return typeStmt(tokens)
     return statement4(tokens)
+
 
 def statement4(tokens: Tokens) -> lang.Stmt:
     if matchWord(tokens, 'IF'):
@@ -658,10 +717,12 @@ def statement4(tokens: Tokens) -> lang.Stmt:
         return forStmt(tokens)
     return statement5(tokens)
 
+
 def statement5(tokens: Tokens) -> lang.Stmt:
     if matchWord(tokens, 'CASE'):
         return caseStmt(tokens)
     return statement6(tokens)
+
 
 def statement6(tokens: Tokens) -> lang.Stmt:
     if matchWord(tokens, 'OUTPUT'):
@@ -682,7 +743,9 @@ def statement6(tokens: Tokens) -> lang.Stmt:
         return assignStmt(tokens)
     raise builtin.ParseError("Unrecognised token", check(tokens))
 
+
 # Main parsing loop
+
 
 def parse(tokens: Tokens) -> Iterable[lang.Stmt]:
     """Select a parsing function to use, from the next token, and use it.

--- a/pseudocode/parser.py
+++ b/pseudocode/parser.py
@@ -267,7 +267,7 @@ def callExpr(tokens: Tokens, callableExpr: lang.NameKeyExpr) -> lang.Call:
     return lang.Call(callableExpr, args)
 
 
-def attrExpr(tokens: Tokens, objExpr: lang.Expr) -> lang.GetAttr:
+def attrExpr(tokens: Tokens, objExpr: lang.GetExpr) -> lang.GetAttr:
     assert (isinstance(objExpr, lang.UnresolvedName)
             or isinstance(objExpr, lang.Call)
             or isinstance(objExpr, lang.GetAttr) or isinstance(
@@ -276,7 +276,7 @@ def attrExpr(tokens: Tokens, objExpr: lang.Expr) -> lang.GetAttr:
     return lang.GetAttr(objExpr, name)
 
 
-def indexExpr(tokens: Tokens, arrayExpr: lang.Expr) -> lang.GetIndex:
+def indexExpr(tokens: Tokens, arrayExpr: lang.GetExpr) -> lang.GetIndex:
     assert (isinstance(arrayExpr, lang.UnresolvedName)
             or isinstance(arrayExpr, lang.Call)
             or isinstance(arrayExpr, lang.GetAttr) or isinstance(

--- a/pseudocode/parser.py
+++ b/pseudocode/parser.py
@@ -286,20 +286,26 @@ def indexExpr(tokens: Tokens, arrayExpr: lang.GetExpr) -> lang.GetIndex:
     return lang.GetIndex(arrayExpr, index)
 
 
+def target(tokens: Tokens, expr: lang.UnresolvedName) -> lang.GetExpr:
+    rootExpr = buildExprWhileWord(tokens,
+                                  parserMap={'[': indexExpr,
+                                             '.': attrExpr},
+                                  # Check for function call
+                                  rootExpr=expr,
+                                  advance=True)
+    return rootExpr
+
+
 def nameExpr(tokens: Tokens) -> lang.NameExpr:
     expr = identifier(tokens)
-    if matchWord(tokens, '('):
-        expr = callExpr(tokens, expr)
-    rootExpr = buildExprWhileWord(
-        tokens,
-        parserMap={
-            '[': indexExpr,
-            '.': attrExpr
-        },
-        # Check for function call
-        rootExpr=expr,
-        advance=True,
-    )
+    rootExpr = buildExprWhileWord(tokens,
+                                  parserMap={'[': indexExpr,
+                                             '.': attrExpr},
+                                  # Check for function call
+                                  rootExpr=(callExpr(tokens, expr)
+                                            if matchWord(tokens, '(')
+                                            else expr),
+                                  advance=True)
     assert (isinstance(rootExpr, lang.UnresolvedName)
             or isinstance(rootExpr, lang.Call)
             or isinstance(rootExpr, lang.GetAttr)

--- a/pseudocode/parser.py
+++ b/pseudocode/parser.py
@@ -507,8 +507,11 @@ def caseStmt(tokens: Tokens) -> lang.Case:
     caseStmts: lang.CaseMap = dict()
     caseMap = parseUntilExpectWord(
         tokens, ['OTHERWISE', 'ENDCASE'],
-        lambda tokens: colonPair(tokens, lambda tokens: literal(tokens), lambda
-                                 tokens: [statement1(tokens)]))
+        lambda tokens: colonPair(
+            tokens,
+            lambda tokens: literal(tokens),
+            lambda tokens: [statement1(tokens)]
+        ))
     for caseValue, stmts in caseMap:
         if caseValue in caseStmts:
             raise builtin.ParseError(f"Repeated CASE value", caseValue.token)


### PR DESCRIPTION
Last chapter we started adding new features just to see what is involved. And we fixed a bug, and uncovered a bunch of issues while trying to please `mypy`.

This chapter is all about defining what Pseudo should and should not do, and getting our Python types to make that easier for us.

We start with a general syntax cleanup in `lang.py`, which is going to be the crux of this chapter. No changes, just making things look nicer, easier on the eye, and less painful to read.