### PR TITLE
31b Defining behaviour: EOF handling and Returns

### DIFF
--- a/main.pseudo
+++ b/main.pseudo
@@ -7,8 +7,7 @@ FUNCTION Respond(Prompt: STRING) RETURNS STRING
       "Hello": RETURN "Oh, hello there!"
       "Hi": RETURN "Hihi!"
       "Yo": RETURN "Wassup?"
-      0: RETURN "Huh?"
-      1: RETURN "No way..."
+      OTHERWISE RETURN "Huh"
     ENDCASE
 ENDFUNCTION
 

--- a/main.pseudo
+++ b/main.pseudo
@@ -2,12 +2,14 @@ DECLARE Test : STRING
 
 Test <- "Hi"
 
-CASE OF Test
-  "Hello": OUTPUT "Oh, hello there!"
-  "Hi": OUTPUT "Hihi!"
-  "Hi": OUTPUT "Hi again!"
-  "Yo": OUTPUT "Wassup?"
-  0: OUTPUT "Huh?"
-  0: OUTPUT "Sense of deja vu ..."
-  1: OUTPUT "No way..."
-ENDCASE
+FUNCTION Respond(Prompt: STRING) RETURNS STRING
+    CASE OF Prompt
+      "Hello": RETURN "Oh, hello there!"
+      "Hi": RETURN "Hihi!"
+      "Yo": RETURN "Wassup?"
+      0: RETURN "Huh?"
+      1: RETURN "No way..."
+    ENDCASE
+ENDFUNCTION
+
+OUTPUT Respond(Test)

--- a/pseudocode/interpreter.py
+++ b/pseudocode/interpreter.py
@@ -10,14 +10,15 @@ from dataclasses import dataclass, field
 
 from . import (builtin, lang, system)
 
+
+
 # ----------------------------------------------------------------------
 
 # Helper functions
 
-
 def expectTypeElseError(exprmode: str,
                         *expected: str,
-                        errmsg: str = "Expected",
+                        errmsg: str="Expected",
                         token: lang.Token) -> None:
     """Takes in a type, followed by one or more expected types.
     Raises an error if the given type is not in the expected types.
@@ -25,27 +26,26 @@ def expectTypeElseError(exprmode: str,
     if not exprmode in expected:
         raise builtin.RuntimeError(f"{errmsg} {expected}", token=token)
 
-
 def declaredElseError(frame: lang.Frame,
                       name: lang.NameKey,
-                      errmsg: str = "Undeclared",
-                      token: Optional[lang.Token] = None) -> None:
+                      errmsg: str="Undeclared",
+                      token: Optional[lang.Token]=None) -> None:
     """Takes in a frame and a name.
     Raises an error if the name is not declared in the frame.
     """
     if not frame.has(name):
         raise builtin.RuntimeError(errmsg, token)
 
-
 def undeclaredElseError(frame: lang.Frame,
                         name: lang.NameKey,
                         errmsg="Already declared",
-                        token: Optional[lang.Token] = None) -> None:
+                        token: Optional[lang.Token]=None) -> None:
     """Takes in a frame and a name.
     Raises an error if the name is already declared in the frame.
     """
     if frame.has(name):
         raise builtin.RuntimeError(errmsg, token)
+
 
 
 @dataclass
@@ -70,46 +70,40 @@ class Interpreter:
         )
 
 
+
 # Evaluators
 # Evaluation functions return the evaluated value of Exprs.
-
 
 def evalIndex(indexExpr: lang.IndexExpr, frame: lang.Frame) -> lang.IndexKey:
     """Returns the evaluated value of an Array's index."""
     indexes: lang.IndexKey = tuple()
     for expr in indexExpr:
         index = evaluate(expr, frame)
-        indexes += (index, )
+        indexes += (index,)
     return indexes
-
 
 def evalLiteral(literal: lang.Literal, frame: lang.Frame) -> lang.PyLiteral:
     return literal.value
 
-
 def evalUnary(expr: lang.Unary, frame: lang.Frame) -> lang.PyLiteral:
     rightval = evaluate(expr.right, frame)
     return expr.oper(rightval)
-
 
 def evalBinary(expr: lang.Binary, frame: lang.Frame) -> lang.PyLiteral:
     leftval = evaluate(expr.left, frame)
     rightval = evaluate(expr.right, frame)
     return expr.oper(leftval, rightval)
 
-
 @singledispatch
 def evalCallable(callable, callargs, frame, **kwargs):
     """Returns the evaluated value of a Builtin/Callable."""
     raise TypeError(f"{type(callable)} passed in evalCallable")
 
-
 # BUG: callargs can't be typed with lang.Exprs
 # Raises NameError: name 'Expr' is not defined
 # Could be some complex interaction with singledispatch
 @evalCallable.register
-def _(callable: lang.Builtin, callargs, frame: lang.Frame,
-      **kwargs) -> lang.PyLiteral:
+def _(callable: lang.Builtin, callargs, frame: lang.Frame, **kwargs) -> lang.PyLiteral:
     if callable.func is system.EOF:
         name = evaluate(callargs[0], frame)  # type: ignore
         file = frame.getValue(name)
@@ -117,7 +111,6 @@ def _(callable: lang.Builtin, callargs, frame: lang.Frame,
         return callable.func(file.iohandler)
     argvals = [evaluate(arg, frame) for arg in callargs]
     return callable.func(*argvals)
-
 
 @evalCallable.register
 def _(callable: lang.Procedure, callargs, frame: lang.Frame, **kwargs) -> None:
@@ -127,26 +120,21 @@ def _(callable: lang.Procedure, callargs, frame: lang.Frame, **kwargs) -> None:
         slot.value = argval
     executeStmts(callable.stmts, callable.frame, **kwargs)
 
-
 @evalCallable.register
-def _(callable: lang.Function, callargs, frame: lang.Frame,
-      **kwargs) -> Union[lang.PyLiteral, lang.Object, lang.Array]:
+def _(callable: lang.Function, callargs, frame: lang.Frame, **kwargs) -> Union[lang.PyLiteral, lang.Object, lang.Array]:
     # Assign args to param slots
     for arg, slot in zip(callargs, callable.params):
         argval = evaluate(arg, frame)
         slot.value = argval
-    returnVal = executeStmts(callable.stmts, callable.frame, **kwargs)
-    assert returnVal, f"None returned from {callable}"
-    return returnVal
+    returnval = executeStmts(callable.stmts, callable.frame, **kwargs)
+    assert returnval, f"None returned from {callable}"
+    return returnval
 
-
-def evalAssign(
-        expr: lang.Assign,
-        frame: lang.Frame) -> Union[lang.PyLiteral, lang.Object, lang.Array]:
+def evalAssign(expr: lang.Assign, frame: lang.Frame) -> Union[lang.PyLiteral, lang.Object, lang.Array]:
+    value = evaluate(expr.expr, frame)
     """Handles assignment of a value to an Object attribute, Array
     index, or Frame name.
     """
-    value = evaluate(expr.expr, frame)
     if isinstance(expr.assignee, lang.GetName):
         frameMap = expr.assignee.frame
         name = str(expr.assignee.name)
@@ -160,90 +148,66 @@ def evalAssign(
         name = str(expr.assignee.name)
         obj.setValue(name, value)
     else:
-        raise builtin.RuntimeError("Invalid Input assignee",
-                                   token=expr.assignee.token)
+        raise builtin.RuntimeError(
+            "Invalid Input assignee", token=expr.assignee.token
+        )
     return value
-
 
 @singledispatch
 def evaluate(expr, frame, **kwargs):
     """Dispatcher for Expr evaluators."""
     raise TypeError(f"Unexpected expr {expr}")
 
-
 @evaluate.register
 def _(expr: lang.Literal, frame: lang.Frame, **kw) -> lang.PyLiteral:
     return evalLiteral(expr, frame)
-
 
 @evaluate.register
 def _(expr: lang.Unary, frame: lang.Frame, **kw) -> lang.PyLiteral:
     return evalUnary(expr, frame)
 
-
 @evaluate.register
 def _(expr: lang.Binary, frame: lang.Frame, **kw) -> lang.PyLiteral:
     return evalBinary(expr, frame)
 
-
 @evaluate.register
-def _(expr: lang.Assign, frame: lang.Frame,
-      **kw) -> Union[lang.PyLiteral, lang.Object, lang.Array]:
+def _(expr: lang.Assign, frame: lang.Frame, **kw) -> Union[lang.PyLiteral, lang.Object, lang.Array]:
     return evalAssign(expr, frame)
 
-
 @evaluate.register
-def _(
-    expr: lang.GetName, frame: lang.Frame, **kw
-) -> Union[lang.PyLiteral, lang.Object, lang.Array, lang.Builtin,
-           lang.Callable]:
+def _(expr: lang.GetName, frame: lang.Frame, **kw) -> Union[lang.PyLiteral, lang.Object, lang.Array, lang.Builtin, lang.Callable]:
     value = expr.frame.getValue(str(expr.name))
     assert not isinstance(value, lang.File), "Unexpected File"
     return value
 
-
 @evaluate.register
-def _(expr: lang.GetIndex, frame: lang.Frame,
-      **kw) -> Union[lang.PyLiteral, lang.Object]:
+def _(expr: lang.GetIndex, frame: lang.Frame, **kw) -> Union[lang.PyLiteral, lang.Object]:
     array = evaluate(expr.array, frame)
     indexes = evalIndex(expr.index, frame)
     return array.getValue(indexes)
-
-
+    
 @evaluate.register
-def _(expr: lang.GetAttr, frame: lang.Frame,
-      **kw) -> Union[lang.PyLiteral, lang.Object]:
+def _(expr: lang.GetAttr, frame: lang.Frame, **kw) -> Union[lang.PyLiteral, lang.Object]:
     obj = evaluate(expr.object, frame)
     return obj.getValue(str(expr.name))
-
-
+    
 @evaluate.register
-def _(expr: lang.Call, frame: lang.Frame,
-      **kw) -> Union[None, lang.PyLiteral, lang.Object, lang.Array]:
+def _(expr: lang.Call, frame: lang.Frame, **kw) -> Union[None, lang.PyLiteral, lang.Object, lang.Array]:
     callable = evaluate(expr.callable, frame)
-    returnVal = evalCallable(callable, expr.args, callable.frame)
-    return returnVal
-
+    return evalCallable(callable, expr.args, callable.frame)
 
 # Executors
 
-
-def executeStmts(
-        stmts: lang.Stmts, frame: lang.Frame,
-        **kwargs) -> Union[None, lang.PyLiteral, lang.Object, lang.Array]:
+def executeStmts(stmts: lang.Stmts, frame: lang.Frame, **kwargs) -> Union[None, lang.PyLiteral, lang.Object, lang.Array]:
     """Execute a list of statements."""
     for stmt in stmts:
         if isinstance(stmt, lang.Return):
             return execReturn(stmt, frame, **kwargs)
         else:
-            returnVal = execute(stmt, frame, **kwargs)
-            if returnVal:
-                return returnVal
+            execute(stmt, frame, **kwargs)
     return None
 
-
-def execReturn(stmt: lang.Return, frame: lang.Frame,
-               **kwargs) -> Union[lang.PyLiteral, lang.Object, lang.Array]:
+def execReturn(stmt: lang.Return, frame: lang.Frame, **kwargs) -> Union[lang.PyLiteral, lang.Object, lang.Array]:
     """Return statements should be explicitly checked for and the
     return value passed back. They should not be dispatched through
     execute().
@@ -251,27 +215,24 @@ def execReturn(stmt: lang.Return, frame: lang.Frame,
     return evaluate(stmt.expr, frame, **kwargs)
 
 
+
 @singledispatch
 def execute(stmt: lang.Stmt, frame: lang.Frame, **kwargs) -> None:
     """Dispatcher for statement executors."""
     raise TypeError(f"Invalid Stmt {stmt}")
 
-
 @execute.register
 def _(stmt: lang.Return, frame: lang.Frame, **kwargs) -> None:
     raise TypeError("Return Stmts should not be dispatched from execute()")
-
-
+    
 @execute.register
-def _(stmt: lang.Output, frame: lang.Frame, *, output: function,
-      **kwargs) -> None:
+def _(stmt: lang.Output, frame: lang.Frame, *, output: function, **kwargs) -> None:
     for expr in stmt.exprs:
         value = evaluate(expr, frame)
         if type(value) is bool:
             value = str(value).upper()
         output(str(value), end='')
     output('')  # Add \n
-
 
 @execute.register
 def _(stmt: lang.Input, frame: lang.Frame, **kwargs) -> None:
@@ -285,76 +246,73 @@ def _(stmt: lang.Input, frame: lang.Frame, **kwargs) -> None:
         obj = evaluate(stmt.key.object, frame)
         name = str(stmt.key.name)
         obj.setValue(name, input())
-    raise builtin.RuntimeError("Invalid Input assignee", token=stmt.key.token)
-
+    raise builtin.RuntimeError(
+        "Invalid Input assignee", token=stmt.key.token
+    )
 
 @execute.register
-def _(stmt: lang.Case, frame: lang.Frame, **kwargs) -> Optional[lang.PyLiteral]:
+def _(stmt: lang.Case, frame: lang.Frame, **kwargs) -> None:
     condValue = evaluate(stmt.cond, frame)
     for caseValue, stmts in stmt.stmtMap.items():
         if evaluate(caseValue, frame) == condValue:
-            return executeStmts(stmts, frame, **kwargs)
+            executeStmts(stmts, frame, **kwargs)
+            break
     else:  # for loop completed normally, i.e. no matching cases
         if stmt.fallback:
-            return executeStmts(stmt.fallback, frame, **kwargs)
-
+            executeStmts(stmt.fallback, frame, **kwargs)
 
 @execute.register
-def _(stmt: lang.If, frame: lang.Frame, **kwargs) -> Optional[lang.PyLiteral]:
+def _(stmt: lang.If, frame: lang.Frame, **kwargs) -> None:
     condValue = evaluate(stmt.cond, frame)
     for caseValue, stmts in stmt.stmtMap.items():
         if evaluate(caseValue, frame) == condValue:
-            return executeStmts(stmts, frame, **kwargs)
+            executeStmts(stmts, frame, **kwargs)
+            break
     else:  # for loop completed normally, i.e. no matching cases
         if stmt.fallback:
-            return executeStmts(stmt.fallback, frame, **kwargs)
-
-
+            executeStmts(stmt.fallback, frame, **kwargs)
+    
 @execute.register
-def _(stmt: lang.While, frame: lang.Frame, **kwargs) -> Optional[lang.PyLiteral]:
+def _(stmt: lang.While, frame: lang.Frame, **kwargs) -> None:
     if stmt.init:
         evaluate(stmt.init, frame, **kwargs)
     while evaluate(stmt.cond, frame) is True:
-        returnVal = executeStmts(stmt.stmts, frame, **kwargs)
-        if returnVal:
-            return returnVal
-
-
+        executeStmts(stmt.stmts, frame, **kwargs)
+    
 @execute.register
-def _(stmt: lang.Repeat, frame: lang.Frame, **kwargs) -> Optional[lang.PyLiteral]:
+def _(stmt: lang.Repeat, frame: lang.Frame, **kwargs) -> None:
     executeStmts(stmt.stmts, frame)
     while evaluate(stmt.cond, frame) is False:
-        returnVal = executeStmts(stmt.stmts, frame)
-        if returnVal:
-            return returnVal
-
+        executeStmts(stmt.stmts, frame)
 
 @execute.register
 def _(stmt: lang.OpenFile, frame: lang.Frame, **kwargs) -> None:
     filename = evaluate(stmt.filename, frame)
-    undeclaredElseError(frame,
-                        filename,
-                        "File already opened",
-                        token=stmt.filename.token)
+    undeclaredElseError(
+        frame, filename, "File already opened", 
+        token=stmt.filename.token
+    )
     frame.declare(filename, 'FILE')
     frame.setValue(
         filename,
-        lang.File(filename, stmt.mode, open(filename, stmt.mode[0].lower())),
+        lang.File(
+            filename,
+            stmt.mode,
+            open(filename, stmt.mode[0].lower())
+        ),
     )
-
-
+    
 @execute.register
 def _(stmt: lang.ReadFile, frame: lang.Frame, **kwargs) -> None:
     filename = evaluate(stmt.filename, frame)
-    declaredElseError(frame,
-                      filename,
-                      "File not open",
-                      token=stmt.filename.token)
+    declaredElseError(
+        frame, filename, "File not open", token=stmt.filename.token
+    )
     file = frame.getValue(filename)
     assert isinstance(file, lang.File), f"Invalid file {file}"
-    expectTypeElseError(frame.getType(filename),
-                        'FILE',
-                        token=stmt.filename.token)
+    expectTypeElseError(
+        frame.getType(filename), 'FILE', token=stmt.filename.token
+    )
     expectTypeElseError(file.mode, 'READ', token=stmt.filename.token)
     varname = evaluate(stmt.target, frame)
     assert isinstance(varname, str), f"Expected str, got {varname!r}"
@@ -363,24 +321,21 @@ def _(stmt: lang.ReadFile, frame: lang.Frame, **kwargs) -> None:
     line = file.iohandler.readline().rstrip()
     # TODO: Type conversion
     frame.setValue(varname, line)
-
-
+    
 @execute.register
 def _(stmt: lang.WriteFile, frame: lang.Frame, **kwargs) -> None:
     filename = evaluate(stmt.filename, frame)
-    declaredElseError(frame,
-                      filename,
-                      "File not open",
-                      token=stmt.filename.token)
+    declaredElseError(
+        frame, filename, "File not open", token=stmt.filename.token
+    )
     file = frame.getValue(filename)
     assert isinstance(file, lang.File), f"Invalid file {file}"
-    expectTypeElseError(frame.getType(filename),
-                        'FILE',
-                        token=stmt.filename.token)
-    expectTypeElseError(file.mode,
-                        'WRITE',
-                        'APPEND',
-                        token=stmt.filename.token)
+    expectTypeElseError(
+        frame.getType(filename), 'FILE', token=stmt.filename.token
+    )
+    expectTypeElseError(
+        file.mode, 'WRITE', 'APPEND', token=stmt.filename.token
+    )
     writedata = evaluate(stmt.data, frame)
     if type(writedata) is bool:
         writedata = str(writedata).upper()
@@ -391,49 +346,41 @@ def _(stmt: lang.WriteFile, frame: lang.Frame, **kwargs) -> None:
         writedata += '\n'
     # TODO: Catch and handle Python file io errors
     file.iohandler.write(writedata)
-
-
+    
 @execute.register
 def _(stmt: lang.CloseFile, frame: lang.Frame, **kwargs) -> None:
     filename = evaluate(stmt.filename, frame)
-    declaredElseError(frame,
-                      filename,
-                      "File not open",
-                      token=stmt.filename.token)
+    declaredElseError(
+        frame, filename, "File not open", token=stmt.filename.token
+    )
     file = frame.getValue(filename)
     assert isinstance(file, lang.File), f"Invalid file {file}"
-    expectTypeElseError(frame.getType(filename),
-                        'FILE',
-                        token=stmt.filename.token)
+    expectTypeElseError(
+        frame.getType(filename), 'FILE', token=stmt.filename.token
+    )
     file.iohandler.close()
     frame.delete(filename)
-
-
+    
 @execute.register
 def _(stmt: lang.CallStmt, frame: lang.Frame, **kwargs) -> None:
     callable = evaluate(stmt.expr.callable, frame)
     evalCallable(callable, stmt.expr.args, callable.frame, **kwargs)
-
-
+    
 @execute.register
 def _(stmt: lang.AssignStmt, frame: lang.Frame, **kwargs) -> None:
     evaluate(stmt.expr, frame, **kwargs)
-
-
+    
 @execute.register
 def _(stmt: lang.DeclareStmt, frame: lang.Frame, **kwargs) -> None:
     pass
-
 
 @execute.register
 def _(stmt: lang.TypeStmt, frame: lang.Frame, **kwargs) -> None:
     pass
 
-
 @execute.register
 def _(stmt: lang.ProcedureStmt, frame: lang.Frame, **kwargs) -> None:
     pass
-
 
 @execute.register
 def _(stmt: lang.FunctionStmt, frame: lang.Frame, **kwargs) -> None:

--- a/pseudocode/interpreter.py
+++ b/pseudocode/interpreter.py
@@ -289,18 +289,7 @@ def _(stmt: lang.Input, frame: lang.Frame, **kwargs) -> None:
 
 
 @execute.register
-def _(stmt: lang.Case, frame: lang.Frame, **kwargs) -> Optional[lang.PyLiteral]:
-    condValue = evaluate(stmt.cond, frame)
-    for caseValue, stmts in stmt.stmtMap.items():
-        if evaluate(caseValue, frame) == condValue:
-            return executeStmts(stmts, frame, **kwargs)
-    else:  # for loop completed normally, i.e. no matching cases
-        if stmt.fallback:
-            return executeStmts(stmt.fallback, frame, **kwargs)
-
-
-@execute.register
-def _(stmt: lang.If, frame: lang.Frame, **kwargs) -> Optional[lang.PyLiteral]:
+def _(stmt: lang.Conditional, frame: lang.Frame, **kwargs) -> Optional[lang.PyLiteral]:
     condValue = evaluate(stmt.cond, frame)
     for caseValue, stmts in stmt.stmtMap.items():
         if evaluate(caseValue, frame) == condValue:

--- a/pseudocode/interpreter.py
+++ b/pseudocode/interpreter.py
@@ -10,15 +10,14 @@ from dataclasses import dataclass, field
 
 from . import (builtin, lang, system)
 
-
-
 # ----------------------------------------------------------------------
 
 # Helper functions
 
+
 def expectTypeElseError(exprmode: str,
                         *expected: str,
-                        errmsg: str="Expected",
+                        errmsg: str = "Expected",
                         token: lang.Token) -> None:
     """Takes in a type, followed by one or more expected types.
     Raises an error if the given type is not in the expected types.
@@ -26,26 +25,27 @@ def expectTypeElseError(exprmode: str,
     if not exprmode in expected:
         raise builtin.RuntimeError(f"{errmsg} {expected}", token=token)
 
+
 def declaredElseError(frame: lang.Frame,
                       name: lang.NameKey,
-                      errmsg: str="Undeclared",
-                      token: Optional[lang.Token]=None) -> None:
+                      errmsg: str = "Undeclared",
+                      token: Optional[lang.Token] = None) -> None:
     """Takes in a frame and a name.
     Raises an error if the name is not declared in the frame.
     """
     if not frame.has(name):
         raise builtin.RuntimeError(errmsg, token)
 
+
 def undeclaredElseError(frame: lang.Frame,
                         name: lang.NameKey,
                         errmsg="Already declared",
-                        token: Optional[lang.Token]=None) -> None:
+                        token: Optional[lang.Token] = None) -> None:
     """Takes in a frame and a name.
     Raises an error if the name is already declared in the frame.
     """
     if frame.has(name):
         raise builtin.RuntimeError(errmsg, token)
-
 
 
 @dataclass
@@ -70,40 +70,46 @@ class Interpreter:
         )
 
 
-
 # Evaluators
 # Evaluation functions return the evaluated value of Exprs.
+
 
 def evalIndex(indexExpr: lang.IndexExpr, frame: lang.Frame) -> lang.IndexKey:
     """Returns the evaluated value of an Array's index."""
     indexes: lang.IndexKey = tuple()
     for expr in indexExpr:
         index = evaluate(expr, frame)
-        indexes += (index,)
+        indexes += (index, )
     return indexes
+
 
 def evalLiteral(literal: lang.Literal, frame: lang.Frame) -> lang.PyLiteral:
     return literal.value
 
+
 def evalUnary(expr: lang.Unary, frame: lang.Frame) -> lang.PyLiteral:
     rightval = evaluate(expr.right, frame)
     return expr.oper(rightval)
+
 
 def evalBinary(expr: lang.Binary, frame: lang.Frame) -> lang.PyLiteral:
     leftval = evaluate(expr.left, frame)
     rightval = evaluate(expr.right, frame)
     return expr.oper(leftval, rightval)
 
+
 @singledispatch
 def evalCallable(callable, callargs, frame, **kwargs):
     """Returns the evaluated value of a Builtin/Callable."""
     raise TypeError(f"{type(callable)} passed in evalCallable")
 
+
 # BUG: callargs can't be typed with lang.Exprs
 # Raises NameError: name 'Expr' is not defined
 # Could be some complex interaction with singledispatch
 @evalCallable.register
-def _(callable: lang.Builtin, callargs, frame: lang.Frame, **kwargs) -> lang.PyLiteral:
+def _(callable: lang.Builtin, callargs, frame: lang.Frame,
+      **kwargs) -> lang.PyLiteral:
     if callable.func is system.EOF:
         name = evaluate(callargs[0], frame)  # type: ignore
         file = frame.getValue(name)
@@ -111,6 +117,7 @@ def _(callable: lang.Builtin, callargs, frame: lang.Frame, **kwargs) -> lang.PyL
         return callable.func(file.iohandler)
     argvals = [evaluate(arg, frame) for arg in callargs]
     return callable.func(*argvals)
+
 
 @evalCallable.register
 def _(callable: lang.Procedure, callargs, frame: lang.Frame, **kwargs) -> None:
@@ -120,21 +127,26 @@ def _(callable: lang.Procedure, callargs, frame: lang.Frame, **kwargs) -> None:
         slot.value = argval
     executeStmts(callable.stmts, callable.frame, **kwargs)
 
+
 @evalCallable.register
-def _(callable: lang.Function, callargs, frame: lang.Frame, **kwargs) -> Union[lang.PyLiteral, lang.Object, lang.Array]:
+def _(callable: lang.Function, callargs, frame: lang.Frame,
+      **kwargs) -> Union[lang.PyLiteral, lang.Object, lang.Array]:
     # Assign args to param slots
     for arg, slot in zip(callargs, callable.params):
         argval = evaluate(arg, frame)
         slot.value = argval
-    returnval = executeStmts(callable.stmts, callable.frame, **kwargs)
-    assert returnval, f"None returned from {callable}"
-    return returnval
+    returnVal = executeStmts(callable.stmts, callable.frame, **kwargs)
+    assert returnVal, f"None returned from {callable}"
+    return returnVal
 
-def evalAssign(expr: lang.Assign, frame: lang.Frame) -> Union[lang.PyLiteral, lang.Object, lang.Array]:
-    value = evaluate(expr.expr, frame)
+
+def evalAssign(
+        expr: lang.Assign,
+        frame: lang.Frame) -> Union[lang.PyLiteral, lang.Object, lang.Array]:
     """Handles assignment of a value to an Object attribute, Array
     index, or Frame name.
     """
+    value = evaluate(expr.expr, frame)
     if isinstance(expr.assignee, lang.GetName):
         frameMap = expr.assignee.frame
         name = str(expr.assignee.name)
@@ -148,66 +160,90 @@ def evalAssign(expr: lang.Assign, frame: lang.Frame) -> Union[lang.PyLiteral, la
         name = str(expr.assignee.name)
         obj.setValue(name, value)
     else:
-        raise builtin.RuntimeError(
-            "Invalid Input assignee", token=expr.assignee.token
-        )
+        raise builtin.RuntimeError("Invalid Input assignee",
+                                   token=expr.assignee.token)
     return value
+
 
 @singledispatch
 def evaluate(expr, frame, **kwargs):
     """Dispatcher for Expr evaluators."""
     raise TypeError(f"Unexpected expr {expr}")
 
+
 @evaluate.register
 def _(expr: lang.Literal, frame: lang.Frame, **kw) -> lang.PyLiteral:
     return evalLiteral(expr, frame)
+
 
 @evaluate.register
 def _(expr: lang.Unary, frame: lang.Frame, **kw) -> lang.PyLiteral:
     return evalUnary(expr, frame)
 
+
 @evaluate.register
 def _(expr: lang.Binary, frame: lang.Frame, **kw) -> lang.PyLiteral:
     return evalBinary(expr, frame)
 
-@evaluate.register
-def _(expr: lang.Assign, frame: lang.Frame, **kw) -> Union[lang.PyLiteral, lang.Object, lang.Array]:
-    return evalAssign(expr, frame)
 
 @evaluate.register
-def _(expr: lang.GetName, frame: lang.Frame, **kw) -> Union[lang.PyLiteral, lang.Object, lang.Array, lang.Builtin, lang.Callable]:
+def _(expr: lang.Assign, frame: lang.Frame,
+      **kw) -> Union[lang.PyLiteral, lang.Object, lang.Array]:
+    return evalAssign(expr, frame)
+
+
+@evaluate.register
+def _(
+    expr: lang.GetName, frame: lang.Frame, **kw
+) -> Union[lang.PyLiteral, lang.Object, lang.Array, lang.Builtin,
+           lang.Callable]:
     value = expr.frame.getValue(str(expr.name))
     assert not isinstance(value, lang.File), "Unexpected File"
     return value
 
+
 @evaluate.register
-def _(expr: lang.GetIndex, frame: lang.Frame, **kw) -> Union[lang.PyLiteral, lang.Object]:
+def _(expr: lang.GetIndex, frame: lang.Frame,
+      **kw) -> Union[lang.PyLiteral, lang.Object]:
     array = evaluate(expr.array, frame)
     indexes = evalIndex(expr.index, frame)
     return array.getValue(indexes)
-    
+
+
 @evaluate.register
-def _(expr: lang.GetAttr, frame: lang.Frame, **kw) -> Union[lang.PyLiteral, lang.Object]:
+def _(expr: lang.GetAttr, frame: lang.Frame,
+      **kw) -> Union[lang.PyLiteral, lang.Object]:
     obj = evaluate(expr.object, frame)
     return obj.getValue(str(expr.name))
-    
+
+
 @evaluate.register
-def _(expr: lang.Call, frame: lang.Frame, **kw) -> Union[None, lang.PyLiteral, lang.Object, lang.Array]:
+def _(expr: lang.Call, frame: lang.Frame,
+      **kw) -> Union[None, lang.PyLiteral, lang.Object, lang.Array]:
     callable = evaluate(expr.callable, frame)
-    return evalCallable(callable, expr.args, callable.frame)
+    returnVal = evalCallable(callable, expr.args, callable.frame)
+    return returnVal
+
 
 # Executors
 
-def executeStmts(stmts: lang.Stmts, frame: lang.Frame, **kwargs) -> Union[None, lang.PyLiteral, lang.Object, lang.Array]:
+
+def executeStmts(
+        stmts: lang.Stmts, frame: lang.Frame,
+        **kwargs) -> Union[None, lang.PyLiteral, lang.Object, lang.Array]:
     """Execute a list of statements."""
     for stmt in stmts:
         if isinstance(stmt, lang.Return):
             return execReturn(stmt, frame, **kwargs)
         else:
-            execute(stmt, frame, **kwargs)
+            returnVal = execute(stmt, frame, **kwargs)
+            if returnVal:
+                return returnVal
     return None
 
-def execReturn(stmt: lang.Return, frame: lang.Frame, **kwargs) -> Union[lang.PyLiteral, lang.Object, lang.Array]:
+
+def execReturn(stmt: lang.Return, frame: lang.Frame,
+               **kwargs) -> Union[lang.PyLiteral, lang.Object, lang.Array]:
     """Return statements should be explicitly checked for and the
     return value passed back. They should not be dispatched through
     execute().
@@ -215,24 +251,27 @@ def execReturn(stmt: lang.Return, frame: lang.Frame, **kwargs) -> Union[lang.PyL
     return evaluate(stmt.expr, frame, **kwargs)
 
 
-
 @singledispatch
 def execute(stmt: lang.Stmt, frame: lang.Frame, **kwargs) -> None:
     """Dispatcher for statement executors."""
     raise TypeError(f"Invalid Stmt {stmt}")
 
+
 @execute.register
 def _(stmt: lang.Return, frame: lang.Frame, **kwargs) -> None:
     raise TypeError("Return Stmts should not be dispatched from execute()")
-    
+
+
 @execute.register
-def _(stmt: lang.Output, frame: lang.Frame, *, output: function, **kwargs) -> None:
+def _(stmt: lang.Output, frame: lang.Frame, *, output: function,
+      **kwargs) -> None:
     for expr in stmt.exprs:
         value = evaluate(expr, frame)
         if type(value) is bool:
             value = str(value).upper()
         output(str(value), end='')
     output('')  # Add \n
+
 
 @execute.register
 def _(stmt: lang.Input, frame: lang.Frame, **kwargs) -> None:
@@ -246,73 +285,76 @@ def _(stmt: lang.Input, frame: lang.Frame, **kwargs) -> None:
         obj = evaluate(stmt.key.object, frame)
         name = str(stmt.key.name)
         obj.setValue(name, input())
-    raise builtin.RuntimeError(
-        "Invalid Input assignee", token=stmt.key.token
-    )
+    raise builtin.RuntimeError("Invalid Input assignee", token=stmt.key.token)
+
 
 @execute.register
-def _(stmt: lang.Case, frame: lang.Frame, **kwargs) -> None:
+def _(stmt: lang.Case, frame: lang.Frame, **kwargs) -> Optional[lang.PyLiteral]:
     condValue = evaluate(stmt.cond, frame)
     for caseValue, stmts in stmt.stmtMap.items():
         if evaluate(caseValue, frame) == condValue:
-            executeStmts(stmts, frame, **kwargs)
-            break
+            return executeStmts(stmts, frame, **kwargs)
     else:  # for loop completed normally, i.e. no matching cases
         if stmt.fallback:
-            executeStmts(stmt.fallback, frame, **kwargs)
+            return executeStmts(stmt.fallback, frame, **kwargs)
+
 
 @execute.register
-def _(stmt: lang.If, frame: lang.Frame, **kwargs) -> None:
+def _(stmt: lang.If, frame: lang.Frame, **kwargs) -> Optional[lang.PyLiteral]:
     condValue = evaluate(stmt.cond, frame)
     for caseValue, stmts in stmt.stmtMap.items():
         if evaluate(caseValue, frame) == condValue:
-            executeStmts(stmts, frame, **kwargs)
-            break
+            return executeStmts(stmts, frame, **kwargs)
     else:  # for loop completed normally, i.e. no matching cases
         if stmt.fallback:
-            executeStmts(stmt.fallback, frame, **kwargs)
-    
+            return executeStmts(stmt.fallback, frame, **kwargs)
+
+
 @execute.register
-def _(stmt: lang.While, frame: lang.Frame, **kwargs) -> None:
+def _(stmt: lang.While, frame: lang.Frame, **kwargs) -> Optional[lang.PyLiteral]:
     if stmt.init:
         evaluate(stmt.init, frame, **kwargs)
     while evaluate(stmt.cond, frame) is True:
-        executeStmts(stmt.stmts, frame, **kwargs)
-    
+        returnVal = executeStmts(stmt.stmts, frame, **kwargs)
+        if returnVal:
+            return returnVal
+
+
 @execute.register
-def _(stmt: lang.Repeat, frame: lang.Frame, **kwargs) -> None:
+def _(stmt: lang.Repeat, frame: lang.Frame, **kwargs) -> Optional[lang.PyLiteral]:
     executeStmts(stmt.stmts, frame)
     while evaluate(stmt.cond, frame) is False:
-        executeStmts(stmt.stmts, frame)
+        returnVal = executeStmts(stmt.stmts, frame)
+        if returnVal:
+            return returnVal
+
 
 @execute.register
 def _(stmt: lang.OpenFile, frame: lang.Frame, **kwargs) -> None:
     filename = evaluate(stmt.filename, frame)
-    undeclaredElseError(
-        frame, filename, "File already opened", 
-        token=stmt.filename.token
-    )
+    undeclaredElseError(frame,
+                        filename,
+                        "File already opened",
+                        token=stmt.filename.token)
     frame.declare(filename, 'FILE')
     frame.setValue(
         filename,
-        lang.File(
-            filename,
-            stmt.mode,
-            open(filename, stmt.mode[0].lower())
-        ),
+        lang.File(filename, stmt.mode, open(filename, stmt.mode[0].lower())),
     )
-    
+
+
 @execute.register
 def _(stmt: lang.ReadFile, frame: lang.Frame, **kwargs) -> None:
     filename = evaluate(stmt.filename, frame)
-    declaredElseError(
-        frame, filename, "File not open", token=stmt.filename.token
-    )
+    declaredElseError(frame,
+                      filename,
+                      "File not open",
+                      token=stmt.filename.token)
     file = frame.getValue(filename)
     assert isinstance(file, lang.File), f"Invalid file {file}"
-    expectTypeElseError(
-        frame.getType(filename), 'FILE', token=stmt.filename.token
-    )
+    expectTypeElseError(frame.getType(filename),
+                        'FILE',
+                        token=stmt.filename.token)
     expectTypeElseError(file.mode, 'READ', token=stmt.filename.token)
     varname = evaluate(stmt.target, frame)
     assert isinstance(varname, str), f"Expected str, got {varname!r}"
@@ -321,21 +363,24 @@ def _(stmt: lang.ReadFile, frame: lang.Frame, **kwargs) -> None:
     line = file.iohandler.readline().rstrip()
     # TODO: Type conversion
     frame.setValue(varname, line)
-    
+
+
 @execute.register
 def _(stmt: lang.WriteFile, frame: lang.Frame, **kwargs) -> None:
     filename = evaluate(stmt.filename, frame)
-    declaredElseError(
-        frame, filename, "File not open", token=stmt.filename.token
-    )
+    declaredElseError(frame,
+                      filename,
+                      "File not open",
+                      token=stmt.filename.token)
     file = frame.getValue(filename)
     assert isinstance(file, lang.File), f"Invalid file {file}"
-    expectTypeElseError(
-        frame.getType(filename), 'FILE', token=stmt.filename.token
-    )
-    expectTypeElseError(
-        file.mode, 'WRITE', 'APPEND', token=stmt.filename.token
-    )
+    expectTypeElseError(frame.getType(filename),
+                        'FILE',
+                        token=stmt.filename.token)
+    expectTypeElseError(file.mode,
+                        'WRITE',
+                        'APPEND',
+                        token=stmt.filename.token)
     writedata = evaluate(stmt.data, frame)
     if type(writedata) is bool:
         writedata = str(writedata).upper()
@@ -346,41 +391,49 @@ def _(stmt: lang.WriteFile, frame: lang.Frame, **kwargs) -> None:
         writedata += '\n'
     # TODO: Catch and handle Python file io errors
     file.iohandler.write(writedata)
-    
+
+
 @execute.register
 def _(stmt: lang.CloseFile, frame: lang.Frame, **kwargs) -> None:
     filename = evaluate(stmt.filename, frame)
-    declaredElseError(
-        frame, filename, "File not open", token=stmt.filename.token
-    )
+    declaredElseError(frame,
+                      filename,
+                      "File not open",
+                      token=stmt.filename.token)
     file = frame.getValue(filename)
     assert isinstance(file, lang.File), f"Invalid file {file}"
-    expectTypeElseError(
-        frame.getType(filename), 'FILE', token=stmt.filename.token
-    )
+    expectTypeElseError(frame.getType(filename),
+                        'FILE',
+                        token=stmt.filename.token)
     file.iohandler.close()
     frame.delete(filename)
-    
+
+
 @execute.register
 def _(stmt: lang.CallStmt, frame: lang.Frame, **kwargs) -> None:
     callable = evaluate(stmt.expr.callable, frame)
     evalCallable(callable, stmt.expr.args, callable.frame, **kwargs)
-    
+
+
 @execute.register
 def _(stmt: lang.AssignStmt, frame: lang.Frame, **kwargs) -> None:
     evaluate(stmt.expr, frame, **kwargs)
-    
+
+
 @execute.register
 def _(stmt: lang.DeclareStmt, frame: lang.Frame, **kwargs) -> None:
     pass
+
 
 @execute.register
 def _(stmt: lang.TypeStmt, frame: lang.Frame, **kwargs) -> None:
     pass
 
+
 @execute.register
 def _(stmt: lang.ProcedureStmt, frame: lang.Frame, **kwargs) -> None:
     pass
+
 
 @execute.register
 def _(stmt: lang.FunctionStmt, frame: lang.Frame, **kwargs) -> None:

--- a/pseudocode/parser.py
+++ b/pseudocode/parser.py
@@ -506,11 +506,10 @@ def caseStmt(tokens: Tokens) -> lang.Case:
     caseStmts: lang.CaseMap = dict()
     caseMap = parseUntilExpectWord(
         tokens, ['OTHERWISE', 'ENDCASE'],
-        lambda tokens: colonPair(
-            tokens,
-            lambda tokens: literal(tokens),
-            lambda tokens: [statement1(tokens)]
-        ))
+        lambda tokens: colonPair(tokens,
+                                 lambda tokens: literal(tokens),
+                                 lambda tokens: [statement1(tokens)])
+    )
     for caseValue, stmts in caseMap:
         if caseValue in caseStmts:
             raise builtin.ParseError(f"Repeated CASE value", caseValue.token)
@@ -684,7 +683,7 @@ def closefileStmt(tokens: Tokens) -> lang.CloseFile:
 #    can be used anywhere except in CASE option statements
 # 5. CASE -> (6)
 #    only accepts single-line statements
-# 6. OUTPUT | INPUT | CALL | Assign | OPEN/READ/WRITE/CLOSEFILE
+# 6. OUTPUT | INPUT | CALL | Assign | OPEN/READ/WRITE/CLOSEFILE -> END
 #    may be used anywhere in a program
 
 

--- a/pseudocode/parser.py
+++ b/pseudocode/parser.py
@@ -752,13 +752,10 @@ def statement6(tokens: Tokens) -> lang.Stmt:
 
 
 def parse(tokens: Tokens) -> Iterable[lang.Stmt]:
-    """Select a parsing function to use, from the next token, and use it.
+    """Select a parsing function to use, from the next token, and use
+    it.
     """
-    lastline = tokens[-1].line
-    tokens += [lang.Token(lastline, 0, 'EOF', '\0', 'EOF')]
     statements = []
     while not atEnd(tokens):
-        # ignore empty lines
-        collectExprsWhileWord(tokens, ['\n'], lambda tokens: None)
         statements += [statement2(tokens)]
     return statements

--- a/pseudocode/parser.py
+++ b/pseudocode/parser.py
@@ -508,14 +508,14 @@ def caseStmt(tokens: Tokens) -> lang.Case:
         tokens, ['OTHERWISE', 'ENDCASE'],
         lambda tokens: colonPair(tokens,
                                  lambda tokens: literal(tokens),
-                                 lambda tokens: [statement1(tokens)])
+                                 lambda tokens: [statement7(tokens)])
     )
     for caseValue, stmts in caseMap:
         if caseValue in caseStmts:
             raise builtin.ParseError(f"Repeated CASE value", caseValue.token)
         caseStmts[caseValue] = stmts
     if matchWord(tokens, 'OTHERWISE'):
-        fallback = [statement6(tokens)]
+        fallback = [statement7(tokens)]
     else:
         fallback = None
     matchWordElseError(tokens, 'ENDCASE', msg="at end of CASE")
@@ -685,6 +685,8 @@ def closefileStmt(tokens: Tokens) -> lang.CloseFile:
 #    only accepts single-line statements
 # 6. OUTPUT | INPUT | CALL | Assign | OPEN/READ/WRITE/CLOSEFILE -> END
 #    may be used anywhere in a program
+# 7. RETURN -> (6)
+#    used within CASE option statements only
 
 
 def statement1(tokens: Tokens) -> lang.Stmt:
@@ -745,6 +747,12 @@ def statement6(tokens: Tokens) -> lang.Stmt:
     if expectType(tokens, 'name'):
         return assignStmt(tokens)
     raise builtin.ParseError("Unrecognised token", check(tokens))
+
+
+def statement7(tokens: Tokens) -> lang.Stmt:
+    if matchWord(tokens, 'RETURN'):
+        return returnStmt(tokens)
+    return statement6(tokens)
 
 
 # Main parsing loop

--- a/pseudocode/parser.py
+++ b/pseudocode/parser.py
@@ -749,8 +749,6 @@ def statement6(tokens: Tokens) -> lang.Stmt:
 
 
 # Main parsing loop
-
-
 def parse(tokens: Tokens) -> Iterable[lang.Stmt]:
     """Select a parsing function to use, from the next token, and use
     it.

--- a/pseudocode/resolver.py
+++ b/pseudocode/resolver.py
@@ -1,3 +1,4 @@
+###############################################################################
 """resolver
 
 verify(statements: list, frame: Frame) -> None
@@ -14,14 +15,12 @@ from itertools import product
 
 from . import builtin, lang
 
-
-
 # **********************************************************************
 
 # Resolver helper functions
 
-def expectTypeElseError(exprtype: lang.Type,
-                        *expected: lang.Type,
+
+def expectTypeElseError(exprtype: lang.Type, *expected: lang.Type,
                         token: lang.Token) -> None:
     """Takes in a type, followed by one or more expected types.
     Raises an error if the given type is not in the expected types.
@@ -29,28 +28,28 @@ def expectTypeElseError(exprtype: lang.Type,
     if exprtype not in expected:
         # Stringify expected types
         typesStr = f"({', '.join(expected)})"
-        raise builtin.LogicError(
-            f"Expected {typesStr}, is {exprtype}", token
-        )
+        raise builtin.LogicError(f"Expected {typesStr}, is {exprtype}", token)
+
 
 def rangeProduct(indexes: lang.IndexRanges) -> Iterator:
     """Takes an iterable of (start, end) tuple pairs.
     Returns an iterator for cartesian product of indexes.
     """
-    ranges = [
-        range(start, end + 1)
-        for (start, end) in indexes
-    ]
+    ranges = [range(start, end + 1) for (start, end) in indexes]
     return product(*ranges)
 
-def resolveName(unresolved: lang.UnresolvedName, frame: lang.Frame) -> lang.GetName:
+
+def resolveName(unresolved: lang.UnresolvedName,
+                frame: lang.Frame) -> lang.GetName:
     """Resolves GetName for the UnresolvedName."""
     exprFrame = frame.lookup(str(unresolved.name))
     if exprFrame is None:
         raise builtin.LogicError("Undeclared", unresolved.token)
     return lang.GetName(exprFrame, unresolved.name)
 
-def resolveNamesInTarget(target: Union[lang.Expr, lang.Stmt], frame: lang.Frame) -> None:
+
+def resolveNamesInTarget(target: Union[lang.Expr, lang.Stmt],
+                         frame: lang.Frame) -> None:
     """Checks the exprOrstmt's slots for UnresolvedName, and replaces
     them with GetNames.
     """
@@ -59,7 +58,9 @@ def resolveNamesInTarget(target: Union[lang.Expr, lang.Stmt], frame: lang.Frame)
         if isinstance(expr, lang.UnresolvedName):
             setattr(target, attr, resolveName(expr, frame))
 
-def resolveExprs(exprs: lang.Exprs, frame: lang.Frame) -> Tuple[lang.Expr, ...]:
+
+def resolveExprs(exprs: lang.Exprs,
+                 frame: lang.Frame) -> Tuple[lang.Expr, ...]:
     """Resolve an iterable of Exprs.
     UnresolvedNames are resolved into GetNames.
 
@@ -70,13 +71,12 @@ def resolveExprs(exprs: lang.Exprs, frame: lang.Frame) -> Tuple[lang.Expr, ...]:
         if isinstance(expr, lang.UnresolvedName):
             expr = resolveName(expr, frame)
         resolve(expr, frame)
-        newexprs += (expr,)
+        newexprs += (expr, )
     return newexprs
 
-def resolveArgsParams(callargs: lang.Args,
-                      params: lang.Params,
-                      frame: lang.Frame, *,
-                      token: lang.Token) -> None:
+
+def resolveArgsParams(callargs: lang.Args, params: lang.Params,
+                      frame: lang.Frame, *, token: lang.Token) -> None:
     """resolveArgsParams() only type-checks the args and stmts of the
     call.
     It does not resolve the callable. This should be carried out first
@@ -89,10 +89,7 @@ def resolveArgsParams(callargs: lang.Args,
         )
     for arg, param in zip(callargs, params):
         # param is a TypedValue slot from either local or frame
-        expectTypeElseError(
-            resolve(arg, frame), param.type, token=arg.token
-        )
-
+        expectTypeElseError(resolve(arg, frame), param.type, token=arg.token)
 
 
 @dataclass
@@ -106,40 +103,32 @@ class Resolver:
         verifyStmts(self.statements, self.frame)
 
 
-    
 # Resolver helpers
-
 def declareByref(declare: lang.Declare, frame: lang.Frame) -> None:
     """Declares BYREF variable in the given frame."""
     assert frame.outer, "Declared name in a frame with no outer"
     name: lang.NameKey = str(declare.name)
-    expectTypeElseError(
-        declare.type, frame.outer.getType(name),
-        token=declare.token
-    )
+    expectTypeElseError(declare.type,
+                        frame.outer.getType(name),
+                        token=declare.token)
     # Reference frame vars in local
     frame.set(name, frame.outer.get(name))
+
 
 def declareByval(declare: lang.Declare,
                  frame: Union[lang.Frame, lang.ObjectTemplate]) -> None:
     """Declares BYVALUE variable in the given frame."""
-    if (
-        isinstance(frame, lang.ObjectTemplate)
-        and declare.type == 'ARRAY'
-    ):
-        raise builtin.LogicError(
-            "ARRAY in TYPE not supported", declare.token
-        )
+    if (isinstance(frame, lang.ObjectTemplate) and declare.type == 'ARRAY'):
+        raise builtin.LogicError("ARRAY in TYPE not supported", declare.token)
     name: lang.NameKey = str(declare.name)
     frame.declare(name, declare.type)
     if declare.type == 'ARRAY':
-        array = lang.Array(
-            typesys=frame.types,
-            ranges=declare.metadata['size'],
-            type=declare.metadata['type'],
-        )
+        array = lang.Array(typesys=frame.types,
+                           ranges=declare.metadata['size'],
+                           type=declare.metadata['type'])
         assert isinstance(frame, lang.Frame), "Frame expected"
         frame.setValue(name, array)
+
 
 def resolveProcCall(expr: lang.Call, frame: lang.Frame) -> lang.Type:
     """Resolve a procedure call.
@@ -149,38 +138,32 @@ def resolveProcCall(expr: lang.Call, frame: lang.Frame) -> lang.Type:
     assert isinstance(expr.callable, lang.GetName), \
         f"Callable {expr.callable} unresolved"
     callableType = resolve(expr.callable, frame)
-    expectTypeElseError(
-        callableType, 'NULL', token=expr.callable.token
-    )
+    expectTypeElseError(callableType, 'NULL', token=expr.callable.token)
     callFrame = expr.callable.frame
     callable = callFrame.getValue(str(expr.callable.name))
     if not isinstance(callable, lang.Procedure):
-        raise builtin.LogicError(
-            "Not PROCEDURE", token=expr.callable.token
-        )
+        raise builtin.LogicError("Not PROCEDURE", token=expr.callable.token)
     expr.args = resolveExprs(expr.args, frame)
-    resolveArgsParams(
-        expr.args, callable.params, frame,
-        token=expr.token
-    )
+    resolveArgsParams(expr.args, callable.params, frame, token=expr.token)
     return callableType
+
 
 @singledispatch
 def resolve(expr, frame, **kw):
     """Dispatcher for Expr resolvers."""
     raise TypeError(f"No resolver found for {expr}")
 
+
 @resolve.register
 def _(expr: lang.Literal, frame: lang.Frame, **kw) -> lang.Type:
     return expr.type
 
+
 @resolve.register
-def _(
-    expr: lang.Declare,
-    frame: Union[lang.Frame, lang.ObjectTemplate],
-    *,
-    passby: lang.Passby='BYVALUE',
-) -> lang.Type:
+def _(expr: lang.Declare,
+      frame: Union[lang.Frame, lang.ObjectTemplate],
+      *,
+      passby: lang.Passby = 'BYVALUE') -> lang.Type:
     """Declare variable in frame with dispatcher."""
     if passby == 'BYVALUE':
         declareByval(expr, frame)
@@ -190,21 +173,19 @@ def _(
         declareByref(expr, frame)
     return expr.type
 
+
 @resolve.register
 def _(expr: lang.Unary, frame: lang.Frame, **kw) -> lang.Type:
     resolveNamesInTarget(expr, frame)
     rType = resolve(expr.right, frame)
     if expr.oper is builtin.sub:
-        expectTypeElseError(
-            rType, *builtin.NUMERIC, token=expr.right.token
-        )
+        expectTypeElseError(rType, *builtin.NUMERIC, token=expr.right.token)
         return rType
     if expr.oper is builtin.NOT:
-        expectTypeElseError(
-            rType, 'BOOLEAN', token=expr.right.token
-        )
+        expectTypeElseError(rType, 'BOOLEAN', token=expr.right.token)
         return 'BOOLEAN'
     raise ValueError(f"Unexpected oper {expr.oper}")
+
 
 @resolve.register
 def _(expr: lang.Binary, frame: lang.Frame, **kw) -> lang.Type:
@@ -216,53 +197,31 @@ def _(expr: lang.Binary, frame: lang.Frame, **kw) -> lang.Type:
         expectTypeElseError(rType, 'BOOLEAN', token=expr.right.token)
         return 'BOOLEAN'
     if expr.oper in (builtin.ne, builtin.eq):
-        expectTypeElseError(
-            lType, *builtin.EQUATABLE, token=expr.left.token
-        )
-        expectTypeElseError(
-            rType, *builtin.EQUATABLE, token=expr.right.token
-        )
-        if not (
-            (lType == 'BOOLEAN' and rType == 'BOOLEAN')
-            or (lType in builtin.NUMERIC and rType in builtin.NUMERIC)
-        ):
+        expectTypeElseError(lType, *builtin.EQUATABLE, token=expr.left.token)
+        expectTypeElseError(rType, *builtin.EQUATABLE, token=expr.right.token)
+        if not ((lType == 'BOOLEAN' and rType == 'BOOLEAN') or
+                (lType in builtin.NUMERIC and rType in builtin.NUMERIC)):
             raise builtin.LogicError(
                 f"Illegal comparison of {lType} and {rType}",
                 token=expr.token,
             )
         return 'BOOLEAN'
     if expr.oper in (builtin.gt, builtin.gte, builtin.lt, builtin.lte):
-        expectTypeElseError(
-            lType, *builtin.NUMERIC, token=expr.left.token
-        )
-        expectTypeElseError(
-            rType, *builtin.NUMERIC, token=expr.right.token
-        )
+        expectTypeElseError(lType, *builtin.NUMERIC, token=expr.left.token)
+        expectTypeElseError(rType, *builtin.NUMERIC, token=expr.right.token)
         return 'BOOLEAN'
-    if expr.oper in (
-        builtin.add, builtin.sub, builtin.mul, builtin.div
-    ):
-        expectTypeElseError(
-            lType, *builtin.NUMERIC, token=expr.left.token
-        )
-        expectTypeElseError(
-            rType, *builtin.NUMERIC, token=expr.right.token
-        )
-        if (
-            (expr.oper is not builtin.div)
-            and (lType == rType == 'INTEGER')
-        ):
+    if expr.oper in (builtin.add, builtin.sub, builtin.mul, builtin.div):
+        expectTypeElseError(lType, *builtin.NUMERIC, token=expr.left.token)
+        expectTypeElseError(rType, *builtin.NUMERIC, token=expr.right.token)
+        if ((expr.oper is not builtin.div) and (lType == rType == 'INTEGER')):
             return 'INTEGER'
         return 'REAL'
     if expr.oper in (builtin.concat, ):
-        expectTypeElseError(
-            lType, 'STRING', token=expr.left.token
-        )
-        expectTypeElseError(
-            rType, 'STRING', token=expr.right.token
-        )
+        expectTypeElseError(lType, 'STRING', token=expr.left.token)
+        expectTypeElseError(rType, 'STRING', token=expr.right.token)
         return 'STRING'
     raise ValueError("No return for Binary")
+
 
 @resolve.register
 def _(expr: lang.Assign, frame: lang.Frame, **kw) -> lang.Type:
@@ -271,6 +230,7 @@ def _(expr: lang.Assign, frame: lang.Frame, **kw) -> lang.Type:
     exprType = resolve(expr.expr, frame)
     expectTypeElseError(exprType, assnType, token=expr.token)
     return assnType
+
 
 @resolve.register
 def _(expr: lang.Call, frame: lang.Frame, **kw) -> lang.Type:
@@ -283,16 +243,13 @@ def _(expr: lang.Call, frame: lang.Frame, **kw) -> lang.Type:
     callableType = resolve(expr.callable, frame)
     callFrame = expr.callable.frame
     callable = callFrame.getValue(str(expr.callable.name))
-    if not (
-        isinstance(callable, lang.Function)
-        or isinstance(callable, lang.Builtin)
-    ):
-        raise builtin.LogicError(
-            "Not FUNCTION", token=expr.callable.token
-        )
+    if not (isinstance(callable, lang.Function)
+            or isinstance(callable, lang.Builtin)):
+        raise builtin.LogicError("Not FUNCTION", token=expr.callable.token)
     expr.args = resolveExprs(expr.args, frame)
     resolveArgsParams(expr.args, callable.params, frame, token=expr.token)
     return callableType
+
 
 @resolve.register
 def _(expr: lang.GetIndex, frame: lang.Frame, **kw) -> lang.Type:
@@ -300,23 +257,20 @@ def _(expr: lang.GetIndex, frame: lang.Frame, **kw) -> lang.Type:
     def intsElseError(frame, *indexes):
         for indexExpr in indexes:
             nameType = resolve(indexExpr, frame)
-            expectTypeElseError(
-                nameType, 'INTEGER', token=indexExpr.token
-            )
+            expectTypeElseError(nameType, 'INTEGER', token=indexExpr.token)
+
     expr.index = resolveExprs(expr.index, frame)
     # Array indexes must be integer
     intsElseError(frame, *expr.index)
     # Arrays in Objects not yet supported; assume frame
     resolveNamesInTarget(expr, frame)
     assert isinstance(expr.array, lang.GetName), "Array unresolved"
-    expectTypeElseError(
-        ## Expect array
-        resolve(expr.array, frame), 'ARRAY', token=expr.token
-    )
+    ## Expect array
+    expectTypeElseError(resolve(expr.array, frame), 'ARRAY', token=expr.token)
     array = expr.array.frame.getValue(str(expr.array.name))
-    # For mypy type-checking
     assert (isinstance(array, lang.Array)), "Invalid ARRAY"
     return array.elementType
+
 
 @resolve.register
 def _(expr: lang.GetAttr, frame: lang.Frame, **kw) -> lang.Type:
@@ -335,56 +289,58 @@ def _(expr: lang.GetAttr, frame: lang.Frame, **kw) -> lang.Type:
         raise builtin.LogicError("Undeclared attribute", expr.token)
     return obj.getType(str(expr.name))
 
+
 @resolve.register
 def _(expr: lang.GetName, frame: lang.Frame, **kw) -> lang.Type:
     """Returns the type of value that name is mapped to in frame."""
     return expr.frame.getType(str(expr.name))
 
 
-
 # Verifier helpers
 
-def transformDeclares(declares: Iterable[lang.Declare],
-                      passby: lang.Passby,
+
+def transformDeclares(declares: Iterable[lang.Declare], passby: lang.Passby,
                       frame: lang.Frame) -> Tuple[lang.TypedValue, ...]:
-    """Takes in a list of Declares. Returns a list of TypedValues.
+    """Takes in a list of Declares. Returns a tuple of TypedValues.
     Used to declare names in a frame/object.
     """
     params: Tuple[lang.TypedValue, ...] = tuple()
     for declaration in declares:
         resolve(declaration, frame, passby=passby)
-        params += (frame.get(str(declaration.name)),)
+        params += (frame.get(str(declaration.name)), )
     return params
 
-    
 
 # Verifiers
 
-def verifyStmts(stmts: lang.Stmts,
-                frame: lang.Frame,
-                returnType: Optional[lang.Type]=None) -> None:
+
+def verifyStmts(stmts: lang.Stmts, frame: lang.Frame,
+                returnType: Optional[lang.Type] = None) -> None:
     """Verify a list of statements."""
     for stmt in stmts:
         verify(stmt, frame)
         if returnType and isinstance(stmt, lang.Return):
-            expectTypeElseError(
-                resolve(stmt.expr, frame), returnType,
-                token=stmt.expr.token
-            )
+            expectTypeElseError(resolve(stmt.expr, frame),
+                                returnType,
+                                token=stmt.expr.token)
+
 
 @singledispatch
 def verify(stmt, frame):
     """Dispatcher for Stmt verifiers."""
     raise TypeError(f"No verifier found for {stmt}")
 
+
 @verify.register
 def _(stmt: lang.Output, frame: lang.Frame) -> None:
     stmt.exprs = resolveExprs(stmt.exprs, frame)
+
 
 @verify.register
 def _(stmt: lang.Input, frame: lang.Frame) -> None:
     resolveNamesInTarget(stmt, frame)
     resolve(stmt.key, frame)
+
 
 @verify.register
 def _(stmt: lang.Case, frame: lang.Frame) -> None:
@@ -397,6 +353,7 @@ def _(stmt: lang.Case, frame: lang.Frame) -> None:
     if stmt.fallback:
         verifyStmts(stmt.fallback, frame)
 
+
 @verify.register
 def _(stmt: lang.If, frame: lang.Frame) -> None:
     resolveNamesInTarget(stmt, frame)
@@ -407,17 +364,16 @@ def _(stmt: lang.If, frame: lang.Frame) -> None:
     if stmt.fallback:
         verifyStmts(stmt.fallback, frame)
 
+
 @verify.register
 def _(stmt: lang.Loop, frame: lang.Frame) -> None:
     resolveNamesInTarget(stmt, frame)
     if stmt.init:
         resolve(stmt.init, frame)
     condType = resolve(stmt.cond, frame)
-    expectTypeElseError(
-        condType, 'BOOLEAN',
-        token=stmt.cond.token
-    )
+    expectTypeElseError(condType, 'BOOLEAN', token=stmt.cond.token)
     verifyStmts(stmt.stmts, frame)
+
 
 @verify.register
 def _(stmt: lang.ProcedureStmt, frame: lang.Frame) -> None:
@@ -441,6 +397,7 @@ def _(stmt: lang.ProcedureStmt, frame: lang.Frame) -> None:
                                      procstmt.expr.token)
     verifyStmts(stmt.stmts, local)
 
+
 @verify.register
 def _(stmt: lang.FunctionStmt, frame: lang.Frame) -> None:
     """Declare a Function in the given frame."""
@@ -457,21 +414,18 @@ def _(stmt: lang.FunctionStmt, frame: lang.Frame) -> None:
     frame.setValue(str(stmt.name), func)
 
     # Check for return statements
-    if not any([
-        isinstance(stmt, lang.Return)
-        for stmt in stmt.stmts
-    ]):
-        raise builtin.LogicError("No RETURN in function",
-                                 stmt.name.token)
+    if not any([isinstance(stmt, lang.Return) for stmt in stmt.stmts]):
+        raise builtin.LogicError("No RETURN in function", stmt.name.token)
     verifyStmts(stmt.stmts, local, stmt.returnType)
+
 
 @verify.register
 def _(stmt: lang.FileStmt, frame: lang.Frame) -> None:
     resolveNamesInTarget(stmt, frame)
-    expectTypeElseError(
-        resolve(stmt.filename, frame), 'STRING',
-        token=stmt.filename.token
-    )
+    expectTypeElseError(resolve(stmt.filename, frame),
+                        'STRING',
+                        token=stmt.filename.token)
+
 
 @verify.register
 def _(stmt: lang.TypeStmt, frame: lang.Frame) -> None:
@@ -482,17 +436,21 @@ def _(stmt: lang.TypeStmt, frame: lang.Frame) -> None:
         resolve(expr, objTemplate)
     frame.types.setTemplate(str(stmt.name), objTemplate)
 
+
 @verify.register
 def _(stmt: lang.CallStmt, frame: lang.Frame) -> None:
     resolveProcCall(stmt.expr, frame)
+
 
 @verify.register
 def _(stmt: lang.AssignStmt, frame: lang.Frame) -> None:
     resolve(stmt.expr, frame)
 
+
 @verify.register
 def _(stmt: lang.DeclareStmt, frame: lang.Frame) -> None:
     resolve(stmt.expr, frame)
+
 
 @verify.register
 def _(stmt: lang.Return, frame: lang.Frame) -> None:

--- a/pseudocode/resolver.py
+++ b/pseudocode/resolver.py
@@ -340,13 +340,14 @@ def verifyStmts(stmts: lang.Stmts,
                 returnType: Optional[lang.Type] = None) -> None:
     """Verify a list of statements."""
     for stmt in stmts:
-        verify(stmt, frame, returnType)
         if isinstance(stmt, lang.Return):
             if not returnType:
                 raise builtin.LogicError("Unexpected RETURN statement")
             expectTypeElseError(resolve(stmt.expr, frame),
                                 returnType,
                                 token=stmt.expr.token)
+        else:
+            verify(stmt, frame, returnType)
 
 
 @singledispatch

--- a/pseudocode/scanner.py
+++ b/pseudocode/scanner.py
@@ -181,6 +181,9 @@ def scan(src: str) -> Tuple[List[lang.Token], List[str]]:
 
     tokens += [makeToken(code, 'EOF', consume(code), 'EOF')]
     code.nextLine()
+    # Remove leading line breaks
+    while islinebreak(tokens[0]):
+        del tokens[0]
     # Remove multiple line breaks
     i = 1
     while i < len(tokens):

--- a/pseudocode/scanner.py
+++ b/pseudocode/scanner.py
@@ -9,17 +9,18 @@ from typing import List, Tuple
 
 from . import builtin, lang
 
-
-
 # Helper functions
+
 
 def atEnd(code: "Code") -> bool:
     """Returns True if at end of code."""
     return check(code) == '\0'
 
+
 def check(code: "Code") -> str:
     """Returns char at cursor."""
     return code.src[code.cursor]
+
 
 def consume(code: "Code") -> str:
     """Returns char at cursor, advances cursor."""
@@ -27,18 +28,21 @@ def consume(code: "Code") -> str:
     code.cursor += 1
     return char
 
-def makeToken(code: "Code", type: lang.Type, word: str, value: Any) -> lang.Token:
+
+def makeToken(code: "Code", type: lang.Type, word: str,
+              value: Any) -> lang.Token:
     """Factory function for a Token."""
     # First char is column 1
     column = code.cursor - code.lineStart - len(word) + 1
     return lang.Token(code.line, column, type, word, value)
 
+
 def islinebreak(token: lang.Token) -> bool:
     return token.word == '\n'
 
 
-
 # Scanning functions
+
 
 def word(code: "Code") -> str:
     """A word is a sequence of chars starting with a letter, and
@@ -48,6 +52,7 @@ def word(code: "Code") -> str:
     while not atEnd(code) and (check(code).isalpha() or check(code).isdigit()):
         token += consume(code)
     return token
+
 
 def number(code: "Code") -> str:
     """A number is a sequence of chars consisting of digits, with 0 or 1
@@ -64,6 +69,7 @@ def number(code: "Code") -> str:
         token += consume(code)
     return token
 
+
 def string(code: "Code") -> str:
     """A string is a sequence of chars that are enclosed in
     double-quotes (").
@@ -74,6 +80,7 @@ def string(code: "Code") -> str:
     if not atEnd(code):
         token += consume(code)
     return token
+
 
 def symbol(code: "Code") -> str:
     """A symbol is a sequence of symbolic chars."""
@@ -87,7 +94,6 @@ def symbol(code: "Code") -> str:
         while not atEnd(code) and not islinebreak(token):
             token += consume(code)
     return token
-
 
 
 class Code:
@@ -114,12 +120,9 @@ class Code:
         self.lines += [self.src[start:end]]
         self.line += 1
         self.lineStart = self.cursor
-        
-    
 
-    
+
 # Main scanning loop
-
 def scan(src: str) -> Tuple[List[lang.Token], List[str]]:
     """Select a scanning function to use, from the next char in the code
     string, and use it.


### PR DESCRIPTION
Having cleaned up GetExprs and SetExprs, let's tackle EOFs.

Right now, the EOF token is added in the parser:
https://github.com/nyjc-computing/pseudo-9608/blob/9c171ab7b051932752d7c14c3a513434704e8002/pseudocode/parser.py#L754-L758

I don't like this. When we split responsibilities, the scanner is supposed to add tokens, and the parser is supposed to parse them. Let's move this to the scanner instead: [e153dca6a0a0b6f60654ad3b2bc4355ba3c5fc34]